### PR TITLE
[FIX] Alerts should be on top of everything else

### DIFF
--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -74,5 +74,6 @@ $header-padding: $default-padding;
 		top: 56px;
 		left: 0;
 		width: 100%;
+		z-index: 10;
 	}
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/804994/51337331-f541d300-1a6d-11e9-8507-dc789e9486b6.png)

After:
![image](https://user-images.githubusercontent.com/804994/51337319-ece99800-1a6d-11e9-8028-8c213aa7e99e.png)
