### PR TITLE
[FIX] Tooltips should be on top of messages and alerts

### DIFF
--- a/src/components/Tooltip/styles.scss
+++ b/src/components/Tooltip/styles.scss
@@ -27,6 +27,7 @@
   visibility: visible;
   opacity: 1;
   transition: opacity $default-time-animation;
+  z-index: 15;
 
   &--hidden {
     visibility: hidden;


### PR DESCRIPTION
Before:
<img width="350" alt="screen shot 2019-01-21 at 10 33 14" src="https://user-images.githubusercontent.com/804994/51475045-63391380-1d68-11e9-8b23-90b4d72d4c12.png">
<img width="350" alt="screen shot 2019-01-21 at 10 33 39" src="https://user-images.githubusercontent.com/804994/51475044-63391380-1d68-11e9-9cbe-861cf49ca46c.png">

After:
<img width="350" alt="screen shot 2019-01-21 at 10 34 16" src="https://user-images.githubusercontent.com/804994/51475042-63391380-1d68-11e9-9f59-58580cf5a90c.png">
<img width="350" alt="screen shot 2019-01-21 at 10 33 57" src="https://user-images.githubusercontent.com/804994/51475043-63391380-1d68-11e9-9fe2-ef8990325035.png">
