### PR TITLE
[FIX] Header title overflow

### DIFF
--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -36,6 +36,8 @@ $header-height-large: 77px;
 		text-overflow: ellipsis;
 
 		.header__title {
+			overflow: hidden;
+			text-overflow: ellipsis;
 			font-size: 16px;
 			font-weight: 500;
 			line-height: 1.5;


### PR DESCRIPTION
Closes #118 

Before:
<img width="298" alt="screen shot 2019-01-22 at 16 31 26" src="https://user-images.githubusercontent.com/804994/51557263-90b6b780-1e63-11e9-9cd9-c6386c6532d7.png">

After:
<img width="297" alt="screen shot 2019-01-22 at 16 31 05" src="https://user-images.githubusercontent.com/804994/51557272-97452f00-1e63-11e9-8e4c-a70d27e3a527.png">
