### PR TITLE
[FIX] Remove visibility listener on unload page

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -135,6 +135,9 @@ export class App extends Component {
 
 		visibility.addListener(this.handleVisibilityChange);
 		this.handleVisibilityChange();
+		window.addEventListener('beforeunload', () => {
+			visibility.removeListener(this.handleVisibilityChange);
+		});
 
 		const configLanguage = () => {
 			const { config: { settings: { language } = {} } = {} } = this.props;


### PR DESCRIPTION
This PR aims to avoid an extra call to `store.setState()` on page unload.