### PR TITLE
[FIX] Unread messages counter

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -109,7 +109,7 @@ export const getAvatarUrl = (username) => (username ? `${ Livechat.client.host }
 
 export const msgTypesNotRendered = ['livechat_video_call', 'livechat_navigation_history', 'au', 'command'];
 
-export const renderMessage = (message = {}) => (!msgTypesNotRendered.includes(message.t));
+export const canRenderMessage = (message = {}) => (!msgTypesNotRendered.includes(message.t));
 
 export const getAttachmentsUrl = (attachments) => attachments && attachments.map((attachment) => {
 	const assetUrl = attachment.image_url || attachment.video_url || attachment.audio_url || attachment.title_link;

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -107,9 +107,9 @@ export const createToken = () => (Math.random().toString(36).substring(2, 15) + 
 
 export const getAvatarUrl = (username) => (username ? `${ Livechat.client.host }/avatar/${ username }` : null);
 
-export const msgTypesNotDisplayed = ['livechat_video_call', 'livechat_navigation_history', 'au'];
+export const msgTypesNotRendered = ['livechat_video_call', 'livechat_navigation_history', 'au', 'command'];
 
-export const renderMessage = (message = {}) => (message.t !== 'command' && !msgTypesNotDisplayed.includes(message.t));
+export const renderMessage = (message = {}) => (!msgTypesNotRendered.includes(message.t));
 
 export const getAttachmentsUrl = (attachments) => attachments && attachments.map((attachment) => {
 	const assetUrl = attachment.image_url || attachment.video_url || attachment.audio_url || attachment.title_link;

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -2,7 +2,7 @@ import format from 'date-fns/format';
 import { Livechat } from '../api';
 import store from '../store';
 import constants from '../lib/constants';
-
+import { renderMessage } from '../components/helpers';
 
 export const loadConfig = async() => {
 	const {
@@ -38,11 +38,12 @@ export const processUnread = async() => {
 	const { minimized, visible, messages } = store.state;
 	if (minimized || !visible) {
 		const { alerts, lastReadMessageId } = store.state;
-		const lastReadMessageIndex = messages.findIndex((item) => item._id === lastReadMessageId);
-		const unreadMessages = messages.slice(lastReadMessageIndex + 1);
+		const renderedMessages = messages.filter((message) => renderMessage(message));
+		const lastReadMessageIndex = renderedMessages.findIndex((item) => item._id === lastReadMessageId);
+		const unreadMessages = renderedMessages.slice(lastReadMessageIndex + 1);
 
 		if (lastReadMessageIndex !== -1) {
-			const lastReadMessage = messages[lastReadMessageIndex];
+			const lastReadMessage = renderedMessages[lastReadMessageIndex];
 			const alertMessage = I18n.t({
 				one: 'One new message since %{since}',
 				other: '%{count} new messages since %{since}',

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -2,7 +2,7 @@ import format from 'date-fns/format';
 import { Livechat } from '../api';
 import store from '../store';
 import constants from '../lib/constants';
-import { renderMessage } from '../components/helpers';
+import { canRenderMessage } from '../components/helpers';
 
 export const loadConfig = async() => {
 	const {
@@ -38,7 +38,7 @@ export const processUnread = async() => {
 	const { minimized, visible, messages } = store.state;
 	if (minimized || !visible) {
 		const { alerts, lastReadMessageId } = store.state;
-		const renderedMessages = messages.filter((message) => renderMessage(message));
+		const renderedMessages = messages.filter((message) => canRenderMessage(message));
 		const lastReadMessageIndex = renderedMessages.findIndex((item) => item._id === lastReadMessageId);
 		const unreadMessages = renderedMessages.slice(lastReadMessageIndex + 1);
 

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -4,7 +4,7 @@ import { Livechat } from '../../api';
 import { Consumer } from '../../store';
 import { loadConfig } from '../../lib/main';
 import constants from '../../lib/constants';
-import { createToken, debounce, getAvatarUrl, renderMessage, throttle } from '../../components/helpers';
+import { createToken, debounce, getAvatarUrl, canRenderMessage, throttle } from '../../components/helpers';
 import Chat from './component';
 import { ModalManager } from '../../components/Modal';
 import { initRoom, closeChat } from './room';
@@ -346,7 +346,7 @@ export const ChatConnector = ({ ref, ...props }) => (
 					phone: (agent.phone && agent.phone[0] && agent.phone[0].phoneNumber) || (agent.customFields && agent.customFields.phone),
 				} : undefined}
 				room={room}
-				messages={messages.filter((message) => renderMessage(message))}
+				messages={messages.filter((message) => canRenderMessage(message))}
 				noMoreMessages={noMoreMessages}
 				emoji={false}
 				uploads={uploads}

--- a/src/routes/Chat/room.js
+++ b/src/routes/Chat/room.js
@@ -1,7 +1,7 @@
 import { Livechat } from '../../api';
 import { store } from '../../store';
 import { route } from 'preact-router';
-import { setCookies, upsert } from '../../components/helpers';
+import { setCookies, upsert, renderMessage } from '../../components/helpers';
 import Commands from '../../lib/commands';
 import { loadConfig, processUnread } from '../../lib/main';
 import { parentCall } from '../../lib/parentCall';
@@ -96,7 +96,13 @@ Livechat.onMessage(async(message) => {
 	await store.setState({
 		messages: upsert(store.state.messages, message, ({ _id }) => _id === message._id, ({ ts }) => ts),
 	});
+
 	await processMessage(message);
+
+	if (renderMessage(message) !== true) {
+		return;
+	}
+
 	await processUnread();
 	await doPlaySound(message);
 });

--- a/src/routes/Chat/room.js
+++ b/src/routes/Chat/room.js
@@ -1,7 +1,7 @@
 import { Livechat } from '../../api';
 import { store } from '../../store';
 import { route } from 'preact-router';
-import { setCookies, upsert, renderMessage } from '../../components/helpers';
+import { setCookies, upsert, canRenderMessage } from '../../components/helpers';
 import Commands from '../../lib/commands';
 import { loadConfig, processUnread } from '../../lib/main';
 import { parentCall } from '../../lib/parentCall';
@@ -99,7 +99,7 @@ Livechat.onMessage(async(message) => {
 
 	await processMessage(message);
 
-	if (renderMessage(message) !== true) {
+	if (canRenderMessage(message) !== true) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #190.

The number of unread messages was counting message types that should not be rendered, such as `livechat_navigation_history`, etc.
 