### PR TITLE
Modal background color

### DIFF
--- a/src/components/Menu/styles.scss
+++ b/src/components/Menu/styles.scss
@@ -128,5 +128,5 @@
 }
 
 .popover-menu__overlay {
-	background-color: rgba(12, 13, 15, 0.2);
+	background-color: $overlay-bg-color;
 }

--- a/src/components/Modal/styles.scss
+++ b/src/components/Modal/styles.scss
@@ -7,9 +7,6 @@ $modal-border-radius: 2 * $default-border-radius;
 $modal-shadow: 0 7px 16px 0 rgba(0, 0, 0, 0.1);
 $modal-background-color: $bg-color-white;
 
-$modal-overlay-background-color: rgba(12, 13, 15, 0.2);
-
-
 :global(.is-blurred) {
 	filter: blur(2px);
 }
@@ -20,7 +17,7 @@ $modal-overlay-background-color: rgba(12, 13, 15, 0.2);
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background-color: $modal-overlay-background-color;
+	background-color: $overlay-bg-color;
 	z-index: 10;
 }
 

--- a/src/components/Modal/styles.scss
+++ b/src/components/Modal/styles.scss
@@ -7,7 +7,7 @@ $modal-border-radius: 2 * $default-border-radius;
 $modal-shadow: 0 7px 16px 0 rgba(0, 0, 0, 0.1);
 $modal-background-color: $bg-color-white;
 
-$modal-overlay-background-color: rgba(255, 255, 255, 0.52);
+$modal-overlay-background-color: rgba(12, 13, 15, 0.2);
 
 
 :global(.is-blurred) {

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -20,3 +20,5 @@ $color-yellow: #FFD21F;
 $color-dark-yellow: #F6C502;
 $color-green: #2DE0A5;
 $color-dark-green: #26D198;
+
+$overlay-bg-color: rgba(12, 13, 15, 0.2);


### PR DESCRIPTION
Closes #192.

Changed the `overlay background color` of the Modal component, applying the same color used in the popup.

![Screen Shot 2019-03-19 at 09 46 46](https://user-images.githubusercontent.com/2067649/54607933-59f9b980-4a2e-11e9-9f11-e342a47d34a9.png)
