### PR TITLE
Update JS/SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@kossnocorp/desvg": "^0.2.0",
-		"@rocket.chat/sdk": "^1.0.0-alpha.26",
+		"@rocket.chat/sdk": "^1.0.0-alpha.27",
 		"date-fns": "^1.29.0",
 		"desvg": "^1.0.2",
 		"fast-async": "^6.3.8",

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -142,7 +142,9 @@ export class App extends Component {
 
 	async initialize() {
 		// TODO: split these behaviors into composable components
-		await Livechat.connect();
+		const { token } = this.props;
+		await Livechat.connect({ token });
+
 		await loadConfig();
 		this.handleTriggers();
 		CustomFields.init();
@@ -265,6 +267,7 @@ const AppConnector = () => (
 					alerts,
 					modal,
 					dispatch,
+					token,
 				}) => (
 					<App
 						config={config}
@@ -278,6 +281,7 @@ const AppConnector = () => (
 						alerts={alerts}
 						modal={modal}
 						dispatch={dispatch}
+						token={token}
 					/>
 				)}
 			</StoreConsumer>

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -3,7 +3,7 @@ import { Router, route } from 'preact-router';
 import queryString from 'query-string';
 import { Livechat } from '../../api';
 import history from '../../history';
-import { loadConfig, clearConnectionAlerts, checkConnecting } from '../../lib/main';
+import { loadConfig, clearConnectionAlerts } from '../../lib/main';
 import CustomFields from '../../lib/customFields';
 import Triggers from '../../lib/triggers';
 import Hooks from '../../lib/hooks';
@@ -128,7 +128,6 @@ export class App extends Component {
 		await dispatch({ alerts: (alerts.push({ id: livechatConnectedAlertId, children: I18n.t('Livechat connected.'), success: true }), alerts) });
 
 		await loadConfig();
-		await checkConnecting();
 		await loadMessages();
 	}
 

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -3,7 +3,7 @@ import { Router, route } from 'preact-router';
 import queryString from 'query-string';
 import { Livechat } from '../../api';
 import history from '../../history';
-import { loadConfig, clearConnectionAlerts } from '../../lib/main';
+import { loadConfig, clearConnectionAlerts, checkConnecting } from '../../lib/main';
 import CustomFields from '../../lib/customFields';
 import Triggers from '../../lib/triggers';
 import Hooks from '../../lib/hooks';
@@ -126,6 +126,9 @@ export class App extends Component {
 		const { livechatConnectedAlertId } = constants;
 		const { alerts, dispatch } = this.props;
 		await dispatch({ alerts: (alerts.push({ id: livechatConnectedAlertId, children: I18n.t('Livechat connected.'), success: true }), alerts) });
+
+		await loadConfig();
+		await checkConnecting();
 		await loadMessages();
 	}
 

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -142,10 +142,9 @@ export class App extends Component {
 
 	async initialize() {
 		// TODO: split these behaviors into composable components
-		const { token } = this.props;
-		await Livechat.connect({ token });
-
+		// Call loadConfig before calling Livechat.connect
 		await loadConfig();
+		await Livechat.connect();
 		this.handleTriggers();
 		CustomFields.init();
 		Hooks.init();
@@ -267,7 +266,6 @@ const AppConnector = () => (
 					alerts,
 					modal,
 					dispatch,
-					token,
 				}) => (
 					<App
 						config={config}
@@ -281,7 +279,6 @@ const AppConnector = () => (
 						alerts={alerts}
 						modal={modal}
 						dispatch={dispatch}
-						token={token}
 					/>
 				)}
 			</StoreConsumer>

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -26,7 +26,6 @@ export const loadConfig = async() => {
 		user,
 		sound: { src, enabled: true, play: false },
 		messages: [],
-		alerts: [],
 		typing: [],
 		noMoreMessages: false,
 		visible: true,
@@ -58,12 +57,6 @@ export const processUnread = async() => {
 
 		await store.setState({ unread: unreadMessages.length });
 	}
-};
-
-export const checkConnecting = async() => {
-	const { agent, config: { settings: { showConnecting } = {} } = {} } = store.state;
-	const connecting = !!(!agent && showConnecting);
-	await store.setState({ connecting });
 };
 
 export const clearConnectionAlerts = async() => {

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -145,3 +145,14 @@ export const loadMoreMessages = async() => {
 	});
 	await store.setState({ loading: false });
 };
+
+export const defaultRoomParams = () => {
+	const params = {};
+
+	const { triggerAgent: { agent } = {} } = store.state;
+	if (agent && agent._id) {
+		Object.assign(params, { agentId: agent._id });
+	}
+
+	return params;
+};

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -3,7 +3,7 @@ import { store } from '../store';
 import { route } from 'preact-router';
 import { setCookies, upsert, canRenderMessage } from '../components/helpers';
 import Commands from '../lib/commands';
-import { loadConfig, processUnread, checkConnecting } from '../lib/main';
+import { loadConfig, processUnread } from '../lib/main';
 import { parentCall } from './parentCall';
 import { handleTranscript } from './transcript';
 
@@ -54,12 +54,10 @@ export const initRoom = async() => {
 			store.setState({ roomAgent });
 			await store.setState({ agent: roomAgent });
 		}
-		checkConnecting();
 	}
 
 	Livechat.onAgentChange(rid, async(agent) => {
 		await store.setState({ agent });
-		checkConnecting();
 	});
 
 	Livechat.onAgentStatusChange(rid, (status) => {

--- a/src/routes/Chat/component.js
+++ b/src/routes/Chat/component.js
@@ -80,7 +80,6 @@ export default class Chat extends Component {
 		avatarResolver,
 		conversationFinishedMessage,
 		loading,
-		connecting,
 		onUpload,
 		messages,
 		uploads = false,
@@ -152,7 +151,6 @@ export default class Chat extends Component {
 				>
 					<Composer onUpload={onUpload}
 						onSubmit={this.handleSubmit}
-						connecting={connecting}
 						onChange={this.handleChangeText}
 						placeholder={I18n.t('Type your message here')}
 						value={text}

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -14,6 +14,14 @@ export class ChatContainer extends Component {
 		connectingAgent: { value: false },
 	}
 
+	checkConnecting = () => {
+		const { connecting } = this.props;
+		if (connecting !== this.state.connectingAgent) {
+			this.state.connectingAgent = connecting;
+			this.handleConnectingAgentAlert(connecting);
+		}
+	}
+
 	grantUser = async() => {
 		const { token, user, guest } = this.props;
 
@@ -27,7 +35,7 @@ export class ChatContainer extends Component {
 	}
 
 	getRoom = async() => {
-		const { alerts, dispatch, room, showConnecting } = this.props;
+		const { alerts, dispatch, room } = this.props;
 
 		if (room) {
 			return room;
@@ -37,7 +45,7 @@ export class ChatContainer extends Component {
 		try {
 			const params = defaultRoomParams();
 			const newRoom = await Livechat.room(params);
-			await dispatch({ room: newRoom, messages: [], noMoreMessages: false, connecting: showConnecting });
+			await dispatch({ room: newRoom, messages: [], noMoreMessages: false });
 			await initRoom();
 			return newRoom;
 		} catch (error) {
@@ -222,6 +230,7 @@ export class ChatContainer extends Component {
 	}
 
 	componentDidMount() {
+		this.checkConnecting();
 		loadMessages();
 	}
 
@@ -242,11 +251,7 @@ export class ChatContainer extends Component {
 	}
 
 	componentDidUpdate() {
-		const { connecting } = this.props;
-		if (connecting !== this.state.connectingAgent) {
-			this.state.connectingAgent = connecting;
-			this.handleConnectingAgentAlert(connecting);
-		}
+		this.checkConnecting();
 	}
 
 	componentWillUnmount() {
@@ -308,7 +313,6 @@ export const ChatConnector = ({ ref, ...props }) => (
 			noMoreMessages,
 			typing,
 			loading,
-			connecting,
 			dispatch,
 			alerts,
 			visible,
@@ -344,7 +348,7 @@ export const ChatConnector = ({ ref, ...props }) => (
 				typingUsernames={Array.isArray(typing) ? typing : []}
 				loading={loading}
 				showConnecting={showConnecting} // setting from server that tells if app needs to show "connecting" sometimes
-				connecting={connecting} // param to show or hide "connecting"
+				connecting={!!(room && !agent && showConnecting)}
 				dispatch={dispatch}
 				departments={departments}
 				allowSwitchingDepartments={allowSwitchingDepartments}

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -7,7 +7,7 @@ import constants from '../../lib/constants';
 import { createToken, debounce, getAvatarUrl, canRenderMessage, throttle } from '../../components/helpers';
 import Chat from './component';
 import { ModalManager } from '../../components/Modal';
-import { initRoom, closeChat, loadMessages, loadMoreMessages } from '../../lib/room';
+import { initRoom, closeChat, loadMessages, loadMoreMessages, defaultRoomParams } from '../../lib/room';
 
 export class ChatContainer extends Component {
 	state = {
@@ -27,7 +27,7 @@ export class ChatContainer extends Component {
 	}
 
 	getRoom = async() => {
-		const { alerts, dispatch, room, triggerAgent: { agent } = {}, showConnecting } = this.props;
+		const { alerts, dispatch, room, showConnecting } = this.props;
 
 		if (room) {
 			return room;
@@ -35,8 +35,8 @@ export class ChatContainer extends Component {
 
 		await dispatch({ loading: true });
 		try {
-			const agentId = agent && agent._id;
-			const newRoom = await Livechat.room({ agentId });
+			const params = defaultRoomParams();
+			const newRoom = await Livechat.room(params);
 			await dispatch({ room: newRoom, messages: [], noMoreMessages: false, connecting: showConnecting });
 			await initRoom();
 			return newRoom;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,7 +30,6 @@ const initialState = {
 		accepted: false,
 	},
 	alerts: [],
-	connecting: false,
 	visible: true,
 	minimized: true,
 	unread: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@rocket.chat/sdk@^1.0.0-alpha.26":
-  version "1.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.26.tgz#1676af65ee88b1b08ad323e82cb835f4585dae15"
-  integrity sha512-aZrIlM9+58CTSS5W68ecAWep9p/PkR0AuGe0zo9UF1w9ePS2U65NqglqUED93a8kZlcnjyQBX3e2+fIvwSXg9g==
+"@rocket.chat/sdk@^1.0.0-alpha.27":
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.27.tgz#9bbcde27ce1fc180b23d45f9fa04132773a45d32"
+  integrity sha512-eC8lMDH4+BPjLxHGcB1DoUPf3HhO4atEfpxg/J7Wi2/+fuTVUv74A5K7H+sTitvVuM9R3xFRXIbjUGIRTx0/gA==
   dependencies:
     "@types/event-emitter" "^0.3.2"
     "@types/eventemitter3" "^2.0.2"
@@ -10690,7 +10690,7 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-paho-mqtt@eclipse/paho.mqtt.javascript#master:
+"paho-mqtt@github:eclipse/paho.mqtt.javascript#master":
   version "1.1.0"
   resolved "https://codeload.github.com/eclipse/paho.mqtt.javascript/tar.gz/9b761defeeb4a627db31d92ae1b0ca91b44b226e"
 


### PR DESCRIPTION
We changed the `endpoint` to get a new Livechat room, allowing to pass the` agentId` that was used to send trigger messages. Then, if the guests send a message and start a new conversation, the agent that will respond to the chat will be the same one that sent the trigger messages.