### PR TITLE
[FIX] Wrong word break

### DIFF
--- a/src/components/Messages/MessageText/styles.scss
+++ b/src/components/Messages/MessageText/styles.scss
@@ -6,7 +6,8 @@ $message-text-font-size: 0.875rem;
 
 .message-text {
 	font-size: $message-text-font-size;
-	word-break: break-all;
+	word-break: break-word;
+	word-wrap: break-word;
 
 	a {
 		text-decoration: underline dotted;


### PR DESCRIPTION
A LiveChat client has detected a wrong behavior when rendering long words, as displayed below:

<img width="360" alt="Screen Shot 2019-04-24 at 19 09 51" src="https://user-images.githubusercontent.com/2067649/56697266-8e633400-66c4-11e9-8ae7-cc169d87e78c.png">
