### PR TITLE
Support thread messages as attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@kossnocorp/desvg": "^0.2.0",
-		"@rocket.chat/sdk": "^1.0.0-alpha.26",
+		"@rocket.chat/sdk": "^1.0.0-alpha.27",
 		"date-fns": "^1.29.0",
 		"desvg": "^1.0.2",
 		"fast-async": "^6.3.8",

--- a/src/components/Messages/Message/index.js
+++ b/src/components/Messages/Message/index.js
@@ -44,7 +44,7 @@ const renderContent = ({ text, system, quoted, me, attachments, attachmentResolv
 					url={attachmentResolver(attachment.title_link)}
 					title={attachment.title}
 				/>) ||
-			(attachment.message_link && renderContent({
+			((attachment.message_link || attachment.tmid) && renderContent({
 				text: attachment.text,
 				quoted: true,
 				attachments: attachment.attachments,

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -122,7 +122,7 @@ export const loadMessages = async() => {
 	}
 
 	await store.setState({ loading: true });
-	const messages = await Livechat.loadMessages(rid).then(async(data) => (normalizeMessages(data)));
+	const messages = await Livechat.loadMessages(rid).then((data) => (normalizeMessages(data)));
 	await initRoom();
 	await store.setState({ messages: (messages || []).reverse(), noMoreMessages: false });
 	await store.setState({ loading: false });
@@ -141,7 +141,7 @@ export const loadMoreMessages = async() => {
 	}
 
 	await store.setState({ loading: true });
-	const moreMessages = await Livechat.loadMessages(rid, { limit: messages.length + 10 }).then(async(data) => (normalizeMessages(data)));
+	const moreMessages = await Livechat.loadMessages(rid, { limit: messages.length + 10 }).then((data) => (normalizeMessages(data)));
 	await store.setState({
 		messages: (moreMessages || []).reverse(),
 		noMoreMessages: messages.length + 10 > moreMessages.length,

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -122,8 +122,7 @@ export const loadMessages = async() => {
 	}
 
 	await store.setState({ loading: true });
-	let messages = await Livechat.loadMessages(rid);
-	messages = await normalizeMessages(messages);
+	const messages = await Livechat.loadMessages(rid).then(async(data) => (normalizeMessages(data)));
 	await initRoom();
 	await store.setState({ messages: (messages || []).reverse(), noMoreMessages: false });
 	await store.setState({ loading: false });
@@ -142,8 +141,7 @@ export const loadMoreMessages = async() => {
 	}
 
 	await store.setState({ loading: true });
-	let moreMessages = await Livechat.loadMessages(rid, { limit: messages.length + 10 });
-	moreMessages = await normalizeMessages(moreMessages);
+	const moreMessages = await Livechat.loadMessages(rid, { limit: messages.length + 10 }).then(async(data) => (normalizeMessages(data)));
 	await store.setState({
 		messages: (moreMessages || []).reverse(),
 		noMoreMessages: messages.length + 10 > moreMessages.length,

--- a/src/lib/threads.js
+++ b/src/lib/threads.js
@@ -54,15 +54,16 @@ const normalizeThreadMessage = async(message) => {
 };
 
 export const normalizeMessage = async(message) => {
-	if (await isThreadMessage(message)) {
+	const isThreadMsg = await isThreadMessage(message);
+	if (isThreadMsg) {
 		return false;
 	}
 
 	if (message && message.tmid && !message.threadMsg) {
-		return await normalizeThreadMessage(message);
+		return normalizeThreadMessage(message);
 	}
 
 	return message;
 };
 
-export const normalizeMessages = async(messages = []) => await Promise.all(messages.filter(async(message) => normalizeMessage(message)));
+export const normalizeMessages = async(messages = []) => await Promise.all(messages.filter((message) => normalizeMessage(message)));

--- a/src/lib/threads.js
+++ b/src/lib/threads.js
@@ -1,0 +1,67 @@
+import { Livechat } from '../api';
+import { store } from '../store';
+import { upsert, createToken } from '../components/helpers';
+
+const addParentMessage = async(parentMessage) => {
+	const { state } = store;
+	const { parentMessages = [] } = state;
+	const { tmid } = parentMessage;
+
+	if (!parentMessages.find((msg) => msg._id === tmid)) {
+		await store.setState({ parentMessages: upsert(parentMessages, parentMessage, ({ _id }) => _id === parentMessage._id, ({ ts }) => ts) });
+	}
+};
+
+const isThreadMessage = async(message) => {
+	if (!(message && message.replies)) {
+		return false;
+	}
+	await addParentMessage(message);
+	return true;
+};
+
+const findParentMessage = async(tmid) => {
+	const { state } = store;
+	const { parentMessages = [], room, alerts } = state;
+
+	let parentMessage = parentMessages.find((msg) => msg._id === tmid);
+	if (!parentMessage) {
+		const { _id: rid } = room;
+		try {
+			parentMessage = await Livechat.message(tmid, { rid });
+			await addParentMessage(parentMessage);
+		} catch (error) {
+			const { data: { error: reason } } = error;
+			const alert = { id: createToken(), children: reason, error: true, timeout: 5000 };
+			await store.setState({ alerts: (alerts.push(alert), alerts) });
+		}
+	}
+
+	return parentMessage;
+};
+
+const normalizeThreadMessage = async(message) => {
+	const { state } = store;
+	const { messages = [] } = state;
+
+	let parentMessage = messages.find((msg) => msg._id === message.tmid);
+	if (!parentMessage) {
+		parentMessage = await findParentMessage(message.tmid);
+	}
+	const { msg, attachments = [] } = parentMessage;
+	return Object.assign(message, { threadMsg: parentMessage, attachments: [{ attachments, text: msg, tmid: message.tmid }] });
+};
+
+export const normalizeMessage = async(message) => {
+	if (await isThreadMessage(message)) {
+		return false;
+	}
+
+	if (message && message.tmid && !message.threadMsg) {
+		return await normalizeThreadMessage(message);
+	}
+
+	return message;
+};
+
+export const normalizeMessages = async(messages = []) => await Promise.all(messages.filter(async(message) => normalizeMessage(message)));

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -7,7 +7,7 @@ import constants from '../../lib/constants';
 import { createToken, debounce, getAvatarUrl, canRenderMessage, throttle } from '../../components/helpers';
 import Chat from './component';
 import { ModalManager } from '../../components/Modal';
-import { initRoom, closeChat, loadMessages, loadMoreMessages } from '../../lib/room';
+import { initRoom, closeChat, loadMessages, loadMoreMessages, defaultRoomParams } from '../../lib/room';
 
 export class ChatContainer extends Component {
 	state = {
@@ -27,7 +27,7 @@ export class ChatContainer extends Component {
 	}
 
 	getRoom = async() => {
-		const { alerts, dispatch, room, triggerAgent: { agent } = {}, showConnecting } = this.props;
+		const { alerts, dispatch, room, showConnecting } = this.props;
 
 		if (room) {
 			return room;
@@ -35,8 +35,8 @@ export class ChatContainer extends Component {
 
 		await dispatch({ loading: true });
 		try {
-			const agentId = agent && agent._id;
-			const newRoom = await Livechat.room({ agentId });
+			const params = defaultRoomParams();
+			const newRoom = await Livechat.room(params);
 			await dispatch({ room: newRoom, messages: [], noMoreMessages: false, connecting: showConnecting });
 			await initRoom();
 			return newRoom;

--- a/src/widget.js
+++ b/src/widget.js
@@ -7,7 +7,7 @@ const log = process.env.NODE_ENV === 'development' ?
 
 
 const WIDGET_OPEN_WIDTH = 365;
-const WIDGET_OPEN_HEIGHT = 510;
+const WIDGET_OPEN_HEIGHT = 525;
 const WIDGET_MINIMIZED_WIDTH = 54;
 const WIDGET_MINIMIZED_HEIGHT = 54;
 const WIDGET_MARGIN = 16;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@rocket.chat/sdk@^1.0.0-alpha.26":
-  version "1.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.26.tgz#1676af65ee88b1b08ad323e82cb835f4585dae15"
-  integrity sha512-aZrIlM9+58CTSS5W68ecAWep9p/PkR0AuGe0zo9UF1w9ePS2U65NqglqUED93a8kZlcnjyQBX3e2+fIvwSXg9g==
+"@rocket.chat/sdk@^1.0.0-alpha.27":
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.27.tgz#9bbcde27ce1fc180b23d45f9fa04132773a45d32"
+  integrity sha512-eC8lMDH4+BPjLxHGcB1DoUPf3HhO4atEfpxg/J7Wi2/+fuTVUv74A5K7H+sTitvVuM9R3xFRXIbjUGIRTx0/gA==
   dependencies:
     "@types/event-emitter" "^0.3.2"
     "@types/eventemitter3" "^2.0.2"
@@ -10690,7 +10690,7 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-paho-mqtt@eclipse/paho.mqtt.javascript#master:
+"paho-mqtt@github:eclipse/paho.mqtt.javascript#master":
   version "1.1.0"
   resolved "https://codeload.github.com/eclipse/paho.mqtt.javascript/tar.gz/9b761defeeb4a627db31d92ae1b0ca91b44b226e"
 


### PR DESCRIPTION
Before the implementation of threads, the payload of `reply` and `quoted` messages were equal, but now the reply messages are not sent as attachments anymore, so we need to fetch the parent message from the server and then render it as an attachment.
