### PR TITLE
Close registration form when registering the user through the Livechat API

### DIFF
--- a/src/routes/Register/container.js
+++ b/src/routes/Register/container.js
@@ -8,10 +8,6 @@ import Register from './component';
 
 export class RegisterContainer extends Component {
 
-	state = {
-		registered: false,
-	}
-
 	getDepartment = (fields = {}) => {
 		let { department } = fields;
 
@@ -34,10 +30,8 @@ export class RegisterContainer extends Component {
 		await dispatch({ loading: true, department });
 		try {
 			await Livechat.grantVisitor({ visitor: { ...fields, token } });
-			this.setState({ registered: true });
-			await loadConfig();
 			parentCall('callback', ['pre-chat-form-submit', fields]);
-			route('/');
+			await loadConfig();
 		} finally {
 			await dispatch({ loading: false });
 		}
@@ -53,9 +47,8 @@ export class RegisterContainer extends Component {
 	componentDidUpdate(prevProps) {
 		const { user: prevUser } = prevProps;
 		const { user } = this.props;
-		const { registered } = this.state;
 
-		if (!registered && !prevUser && user) {
+		if (!prevUser && user && user._id) {
 			route('/');
 		}
 	}

--- a/src/routes/Register/container.js
+++ b/src/routes/Register/container.js
@@ -6,8 +6,11 @@ import { loadConfig } from '../../lib/main';
 import { Consumer } from '../../store';
 import Register from './component';
 
-
 export class RegisterContainer extends Component {
+
+	state = {
+		registered: false,
+	}
 
 	getDepartment = (fields = {}) => {
 		let { department } = fields;
@@ -31,6 +34,7 @@ export class RegisterContainer extends Component {
 		await dispatch({ loading: true, department });
 		try {
 			await Livechat.grantVisitor({ visitor: { ...fields, token } });
+			this.setState({ registered: true });
 			await loadConfig();
 			parentCall('callback', ['pre-chat-form-submit', fields]);
 			route('/');
@@ -43,6 +47,16 @@ export class RegisterContainer extends Component {
 		const { guestDepartment, departments } = this.props;
 		if (departments && departments.some((dept) => dept._id === guestDepartment)) {
 			return guestDepartment;
+		}
+	}
+
+	componentDidUpdate(prevProps) {
+		const { user: prevUser } = prevProps;
+		const { user } = this.props;
+		const { registered } = this.state;
+
+		if (!registered && !prevUser && user) {
+			route('/');
 		}
 	}
 
@@ -83,6 +97,7 @@ export const RegisterConnector = ({ ref, ...props }) => (
 			loading = false,
 			token,
 			dispatch,
+			user,
 		}) => (
 			<RegisterContainer
 				ref={ref}
@@ -104,6 +119,7 @@ export const RegisterConnector = ({ ref, ...props }) => (
 				loading={loading}
 				token={token}
 				dispatch={dispatch}
+				user={user}
 			/>
 		)}
 	</Consumer>


### PR DESCRIPTION
Closes #196.

Since the Livechat Router is not based on store/state, when a user is registered through the Livechat API, the registration form needs to detect this change and redirect it to `Chat` container.