### PR TITLE
[FIX] Widget height on mobile browsers

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -77,8 +77,17 @@ const updateWidgetStyle = (isOpened) => {
 
 	if (isOpened) {
 		widget.style.left = smallScreen ? '0' : 'auto';
-		widget.style.width = smallScreen ? '100vw' : `${ WIDGET_MARGIN + WIDGET_OPEN_WIDTH + WIDGET_MARGIN }px`;
-		widget.style.height = smallScreen ? '100vh' :
+
+		/**
+               * If we use widget.style.width = smallScreen ? '100vw' : ...
+               * In above case some browser's viewport width is not rendered correctly
+               * so, as 100vm will resolve to 100% of the current viewport height,
+               * so fixed it to 100% avoiding problem for some browsers. Similar resolution
+               * for widget.style.height
+               */
+
+		widget.style.width = smallScreen ? '100%' : `${ WIDGET_MARGIN + WIDGET_OPEN_WIDTH + WIDGET_MARGIN }px`;
+		widget.style.height = smallScreen ? '100%' :
 			`${ WIDGET_MARGIN + WIDGET_OPEN_HEIGHT + WIDGET_MARGIN + WIDGET_MINIMIZED_HEIGHT + WIDGET_MARGIN }px`;
 	} else {
 		widget.style.left = 'auto';


### PR DESCRIPTION
Problem was with `100vw`, chrome was not able to get it correctly, so as this converts to `100%` in the end so changed it to 100% only.