### PR TITLE
[FIX] Replace messages list key prop

### DIFF
--- a/src/components/Messages/MessageList/index.js
+++ b/src/components/Messages/MessageList/index.js
@@ -116,7 +116,7 @@ export class MessageList extends MemoizedComponent {
 
 			items.push(
 				<Message
-					key={message.ts}
+					key={message._id}
 					attachmentResolver={attachmentResolver}
 					avatarResolver={avatarResolver}
 					use="li"


### PR DESCRIPTION
There was a bug when rendering trigger messages, the rendering was broken, look:

![Screen Shot 2019-06-17 at 14 31 48](https://user-images.githubusercontent.com/2067649/59625235-2a327e80-910f-11e9-9199-1844369540ce.png)


After replacing the key field from `ts` to `_id`, everything works fine again.
