### PR TITLE
[NEW] Add new API methods to minimize / maximize the Widget

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -122,7 +122,7 @@ export class App extends Component {
 		setWidgetLanguage();
 		const { minimized, iframe: { visible } } = this.props;
 		parentCall(minimized ? 'minimizeWindow' : 'restoreWindow');
-		parentCall(visible ? 'showWidgetIframe' : 'hideWidgetIframe');
+		parentCall(visible ? 'showWidget' : 'hideWidget');
 
 		visibility.addListener(this.handleVisibilityChange);
 		this.handleVisibilityChange();

--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -116,13 +116,23 @@ const api = {
 	showWidget() {
 		const { iframe } = store.state;
 		store.setState({ iframe: { ...iframe, visible: true } });
-		parentCall('showWidgetIframe');
+		parentCall('showWidget');
 	},
 
 	hideWidget() {
 		const { iframe } = store.state;
 		store.setState({ iframe: { ...iframe, visible: false } });
-		parentCall('hideWidgetIframe');
+		parentCall('hideWidget');
+	},
+
+	minimizeWidget() {
+		store.setState({ minimized: true });
+		parentCall('closeWidget');
+	},
+
+	maximizeWidget() {
+		store.setState({ minimized: false });
+		parentCall('openWidget');
 	},
 };
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -61,4 +61,3 @@ export const processUnread = async () => {
 		await store.setState({ unread: unreadMessages.length });
 	}
 };
-

--- a/src/widget.js
+++ b/src/widget.js
@@ -211,12 +211,12 @@ const api = {
 		emitCallback(eventName, data);
 	},
 
-	showWidgetIframe() {
+	showWidget() {
 		iframe.style.display = 'initial';
 		emitCallback('show-widget');
 	},
 
-	hideWidgetIframe() {
+	hideWidget() {
 		iframe.style.display = 'none';
 		emitCallback('hide-widget');
 	},
@@ -275,6 +275,14 @@ function showWidget() {
 
 function hideWidget() {
 	callHook('hideWidget');
+}
+
+function maximizeWidget() {
+	callHook('maximizeWidget');
+}
+
+function minimizeWidget() {
+	callHook('minimizeWidget');
 }
 
 const currentPage = {
@@ -351,6 +359,8 @@ window.RocketChat.livechat = {
 	setLanguage,
 	showWidget,
 	hideWidget,
+	maximizeWidget,
+	minimizeWidget,
 
 	// callbacks
 	onChatMaximized(fn) { registerCallback('chat-maximized', fn); },


### PR DESCRIPTION
Closes #187

New method to minimize the widget:
```
RocketChat(function() {
    this.minimizeWidget();
});
```

New method to maximize the widget:
```
RocketChat(function() {
    this.maximizeWidget();
});
```