### PR TITLE
[FIX] Support Webpack relative output path

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -1,12 +1,13 @@
 /* eslint-disable quote-props */
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
+
 import webpackOverride from './webpackOverride.config';
 
 
 export default (config, env/* , helpers */) => {
 	if (env.production) {
-		config.output.publicPath = '/livechat/';
+		config.output.publicPath = 'livechat/';
 	}
 
 	config = webpackOverride(config);


### PR DESCRIPTION
Closes #289 
Closes #290 

When the `Rocket.Chat` runs in a subfolder, the Livechat chunk files aren't loaded because of the current Webpack config.

I'm sharing a few screenshots showing the test of running Rocket.Chat in a subfolder:

![Screen Shot 2019-09-16 at 13 13 35](https://user-images.githubusercontent.com/2067649/64975884-67311d00-d886-11e9-8622-0971d2dd7bdc.png)

Old **index.html:**

![Screen Shot 2019-09-16 at 13 14 50](https://user-images.githubusercontent.com/2067649/64975904-757f3900-d886-11e9-9836-42c03a8fcc9e.png)

![Screen Shot 2019-09-16 at 13 14 59](https://user-images.githubusercontent.com/2067649/64975918-7dd77400-d886-11e9-8704-6b20d7dfac54.png)

New **index.html(relative path):**

![Screen Shot 2019-09-16 at 13 22 50](https://user-images.githubusercontent.com/2067649/64975972-a1022380-d886-11e9-8036-01dde7151b53.png)

![Screen Shot 2019-09-16 at 13 22 55](https://user-images.githubusercontent.com/2067649/64975990-ab242200-d886-11e9-8cba-bd5a2f45fd67.png)

![Screen Shot 2019-09-16 at 13 23 04](https://user-images.githubusercontent.com/2067649/64976017-b6774d80-d886-11e9-9248-9156667bcddd.png)

