### PR TITLE
[FIX] Registration Form changes not being detected

### DIFF
--- a/src/routes/Register/component.js
+++ b/src/routes/Register/component.js
@@ -116,6 +116,8 @@ export default class Register extends Component {
 		} else if (!showDepartmentField) {
 			this.setState({ department: null });
 		}
+
+		this.validateAll();
 	}
 
 	render({ title, color, message, loading, departments, ...props }, { name, email, department }) {


### PR DESCRIPTION
Closes #282 

The validation method was not being fired when the Registration Form fields change from the store.
When external users call the API methods, such as `setGuestEmail` or `setGuestName`, the internal state changes, but the `Start Chat` button keeps disabled because of the validation method wasn't be fired.