### PR TITLE
[NEW] Add setting to display a custom chat finished text

### DIFF
--- a/src/routes/ChatFinished/container.js
+++ b/src/routes/ChatFinished/container.js
@@ -22,6 +22,7 @@ export const ChatFinishedConnector = ({ ref, ...props }) => (
 			config: {
 				messages: {
 					conversationFinishedMessage: greeting,
+					conversationFinishedText: message,
 				} = {},
 				theme: {
 					color,
@@ -45,6 +46,7 @@ export const ChatFinishedConnector = ({ ref, ...props }) => (
 				}}
 				title={I18n.t('Chat Finished')}
 				greeting={greeting}
+				message={message}
 			/>
 		)}
 	</Consumer>


### PR DESCRIPTION
Closes #303 
Related to https://github.com/RocketChat/Rocket.Chat/pull/15577

Adds a new setting to set a custom text message which will be displayed in the `Chat Finished` container/component.

![Screen Shot 2019-10-14 at 14 24 26](https://user-images.githubusercontent.com/2067649/66771518-d2274100-ee90-11e9-9aaf-a05451a9f3fb.png)
