### PR TITLE
[FIX] API method calls

### DIFF
--- a/src/lib/customFields.js
+++ b/src/lib/customFields.js
@@ -32,14 +32,20 @@ class CustomFields {
 		store.off('change', this.handleStoreChange);
 	}
 
-	handleStoreChange(state, prevState) {
+	handleStoreChange(state) {
 		const { user } = state;
-		const { user: prevUser } = prevState;
+		const { _started } = CustomFields.instance;
 
-		if (!prevUser && user && user._id) {
-			CustomFields.instance._started = true;
-			CustomFields.instance.processCustomFields();
+		if (_started) {
+			return;
 		}
+
+		if (!user) {
+			return;
+		}
+
+		CustomFields.instance._started = true;
+		CustomFields.instance.processCustomFields();
 	}
 
 	processCustomFields() {

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -80,7 +80,6 @@ export const initRoom = async () => {
 	});
 
 	setCookies(rid, token);
-	parentCall('callback', 'chat-started');
 };
 
 Livechat.onTyping((username, isTyping) => {

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -4,6 +4,7 @@ import { route } from 'preact-router';
 import { Livechat } from '../../api';
 import { Consumer } from '../../store';
 import { loadConfig } from '../../lib/main';
+import { parentCall } from '../../lib/parentCall';
 import constants from '../../lib/constants';
 import { createToken, debounce, getAvatarUrl, canRenderMessage, throttle, upsert } from '../../components/helpers';
 import Chat from './component';
@@ -61,6 +62,8 @@ export class ChatContainer extends Component {
 			const newRoom = await Livechat.room(params);
 			await dispatch({ room: newRoom, messages: [], noMoreMessages: false });
 			await initRoom();
+
+			parentCall('callback', 'chat-started');
 			return newRoom;
 		} catch (error) {
 			const { data: { error: reason } } = error;


### PR DESCRIPTION
- Fix the `onChatStarted` call, that was being called in the wrong place. Due to that, the callback method was being triggered every time de widget got to the room, even when the room already existed.
- Fix the logic when starting the `CustomFields` lib. Since the user is stored in the local storage, when the script was reloaded the `Custom Fields` lib was not being started again.