### PR TITLE
[FIX] Unread messages alert

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -112,7 +112,7 @@ export const createToken = () => Math.random().toString(36).substring(2, 15) + M
 
 export const getAvatarUrl = (username) => (username ? `${ Livechat.client.host }/avatar/${ username }` : null);
 
-export const msgTypesNotRendered = ['livechat_video_call', 'livechat_navigation_history', 'au', 'command'];
+export const msgTypesNotRendered = ['livechat_video_call', 'livechat_navigation_history', 'au', 'command', 'livechat-close'];
 
 export const canRenderMessage = (message = {}) => !msgTypesNotRendered.includes(message.t);
 


### PR DESCRIPTION
The unread messages alert was being displayed when receiving the `livechat-close` system message, as shown below:

![Screen Shot 2019-11-11 at 17 35 59](https://user-images.githubusercontent.com/2067649/68619428-3cd89600-04aa-11ea-9973-6833bd2cec1d.png)
