### PR TITLE
[FIX] Date-fns language import

### DIFF
--- a/src/lib/locale.js
+++ b/src/lib/locale.js
@@ -39,11 +39,20 @@ export const configLanguage = () => {
 export const setWidgetLanguage = () => I18n.changeLocale(normalizeLanguageString(configLanguage() || browserLanguage()));
 
 export const getDateFnsLocale = () => {
-	const supportedLocales = ['ar', 'be', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'eo', 'es', 'fi', 'fil', 'fr', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ko', 'mk', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'th', 'tr', 'zh_cn', 'zh_tw'];
+	const supportedLocales = [
+		'af', 'ar', 'be', 'bg', 'bn', 'ca', 'cs', 'cy', 'da', 'de',
+		'el', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'eo', 'es', 'et',
+		'fa-IR', 'fi', 'fr', 'fr-CA', 'gl', 'gu', 'he', 'hi', 'hr',
+		'hu', 'hy', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'ko', 'lt',
+		'lv', 'nb', 'nl', 'nn', 'pl', 'pt', 'pt-BR', 'ro', 'ru', 'sk',
+		'sl', 'sr', 'sr-Latn', 'sv', 'ta', 'te', 'th', 'tr', 'ug',
+		'uk', 'vi', 'zh_CN', 'zh_TW',
+	];
+
 	let fullLanguage = configLanguage() || browserLanguage();
 	fullLanguage = fullLanguage.toLowerCase();
 	const [languageCode] = fullLanguage.split ? fullLanguage.split(/[-_]/) : [];
-	const locale = [fullLanguage, languageCode, 'en'].find((lng) => supportedLocales.indexOf(lng) > -1);
+	const locale = [fullLanguage, languageCode, 'en-US'].find((lng) => supportedLocales.indexOf(lng) > -1);
 	// eslint-disable-next-line import/no-dynamic-require
 	return require(`date-fns/locale/${ locale }/index.js`);
 };


### PR DESCRIPTION
One more issue detected after upgrading the `date-fns` package version.

![Screen Shot 2019-12-03 at 18 35 21](https://user-images.githubusercontent.com/2067649/70092164-69d91e00-15fc-11ea-9b89-da738d94dbe4.png)

The new version has changed some old supported languages and also added new ones. 