### PR TITLE
[NEW] Add Service Offline callback

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -49,6 +49,7 @@ export class App extends Component {
 			}
 
 			if (!online) {
+				parentCall('callback', 'no-agent-online');
 				return route('/leave-message');
 			}
 

--- a/src/lib/parentCall.js
+++ b/src/lib/parentCall.js
@@ -1,3 +1,5 @@
+import { validCallbacks } from '../widget';
+
 export function parentCall(method, args = []) {
 	const data = {
 		src: 'rocketchat',
@@ -7,3 +9,5 @@ export function parentCall(method, args = []) {
 
 	window.parent.postMessage(data, '*');
 }
+
+export const runCallbackEventEmitter = (callbackName, data) => validCallbacks.includes(callbackName) && parentCall('callback', [callbackName, data]);

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -4,7 +4,7 @@ import { route } from 'preact-router';
 import { Livechat } from '../../api';
 import { Consumer } from '../../store';
 import { loadConfig } from '../../lib/main';
-import { parentCall } from '../../lib/parentCall';
+import { parentCall, runCallbackEventEmitter } from '../../lib/parentCall';
 import constants from '../../lib/constants';
 import { createToken, debounce, getAvatarUrl, canRenderMessage, throttle, upsert } from '../../components/helpers';
 import Chat from './component';
@@ -69,6 +69,8 @@ export class ChatContainer extends Component {
 			const { data: { error: reason } } = error;
 			const alert = { id: createToken(), children: I18n.t('Error starting a new conversation: %{reason}', { reason }), error: true, timeout: 10000 };
 			await dispatch({ loading: false, alerts: (alerts.push(alert), alerts) });
+
+			runCallbackEventEmitter(reason);
 			throw error;
 		} finally {
 			await dispatch({ loading: false });

--- a/src/widget.js
+++ b/src/widget.js
@@ -23,7 +23,7 @@ let smallScreen = false;
 let bodyStyle;
 let scrollPosition;
 
-const validCallbacks = [
+export const validCallbacks = [
 	'chat-maximized',
 	'chat-minimized',
 	'chat-started',
@@ -35,6 +35,7 @@ const validCallbacks = [
 	'assign-agent',
 	'agent-status-change',
 	'queue-position-change',
+	'no-agent-online',
 ];
 
 const callbacks = new EventEmitter();
@@ -374,6 +375,7 @@ window.RocketChat.livechat = {
 	onAssignAgent(fn) { registerCallback('assign-agent', fn); },
 	onAgentStatusChange(fn) { registerCallback('agent-status-change', fn); },
 	onQueuePositionChange(fn) { registerCallback('queue-position-change', fn); },
+	onServiceOffline(fn) { registerCallback('no-agent-online', fn); },
 };
 
 // proccess queue


### PR DESCRIPTION
This PR allows registering a new callback on the widget API to notify the client when the Livechat Service is offline(`no-agent-online`).
Also, it will be possible to auto-emitter the callback events when the event name is a valid callback, such as the `no-agent-online`.