### PR TITLE
Corrected German title for  finished chat

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -6,7 +6,7 @@
     "cancel_caeb1e68": "Abbrechen",
     "change_department_1d671538": "Abteilung wechseln",
     "change_department_523a16e8": "Abteilung wechseln",
-    "chat_finished_effbd589": "Chat Beendet",
+    "chat_finished_effbd589": "Chat beendet",
     "choose_a_department_b106da55": "Wählen Sie eine Abteilung",
     "choose_a_department_fe9755fd": "Wählen Sie eine Abteilung",
     "choose_an_option_26ac97d2": "Wählen Sie eine Option",


### PR DESCRIPTION
This pull request corrects the German upper and lower case for the label of finished chat.