### PR TITLE
[NEW] Add Cross-tab communication on the same origin

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -90,7 +90,7 @@ export function getInsertIndex(array, item, ranking) {
 	return array.length > 0 ? array.length : 0;
 }
 
-export function upsert(array, item, predicate, ranking) {
+export function upsert(array = [], item, predicate, ranking) {
 	const index = array.findIndex(predicate);
 
 	if (index > -1) {

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -199,3 +199,12 @@ export const defaultRoomParams = () => {
 
 	return params;
 };
+
+store.on('change', (state, prevState) => {
+	// Cross-tab communication
+	// Detects when a room is created and then route to the correct container
+	if (!prevState.room && state.room) {
+		route('/');
+	}
+});
+

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -14,6 +14,7 @@ import { normalizeQueueAlert } from '../../lib/api';
 
 export class ChatContainer extends Component {
 	state = {
+		room: null,
 		connectingAgent: false,
 		queueSpot: 0,
 		triggerQueueMessage: true,
@@ -34,6 +35,15 @@ export class ChatContainer extends Component {
 			this.state.estimatedWaitTime = newEstimatedWaitTime;
 			await this.handleQueueMessage(connecting, queueInfo);
 			await this.handleConnectingAgentAlert(newConnecting, normalizeQueueAlert(queueInfo));
+		}
+	}
+
+	checkRoom = () => {
+		const { room } = this.props;
+		const { room: stateRoom } = this.state;
+		if (room && (!stateRoom || room._id !== stateRoom._id)) {
+			this.state.room = room;
+			setTimeout(loadMessages, 500);
 		}
 	}
 
@@ -270,8 +280,8 @@ export class ChatContainer extends Component {
 		});
 	}
 
-	componentDidMount() {
-		this.checkConnectingAgent();
+	async componentDidMount() {
+		await this.checkConnectingAgent();
 		loadMessages();
 	}
 
@@ -291,8 +301,9 @@ export class ChatContainer extends Component {
 		}
 	}
 
-	componentDidUpdate() {
-		this.checkConnectingAgent();
+	async componentDidUpdate() {
+		await this.checkConnectingAgent();
+		this.checkRoom();
 	}
 
 	componentWillUnmount() {
@@ -387,7 +398,7 @@ export const ChatConnector = ({ ref, ...props }) => (
 					} : undefined,
 				} : undefined}
 				room={room}
-				messages={messages.filter((message) => canRenderMessage(message))}
+				messages={messages && messages.filter((message) => canRenderMessage(message))}
 				noMoreMessages={noMoreMessages}
 				emoji={false}
 				uploads={uploads}

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -63,7 +63,7 @@ export default class Store extends EventEmitter {
 		for (const ignoredKey of this.dontPersist) {
 			nonPeristable[ignoredKey] = prevState[ignoredKey];
 		}
-		this._state = { ...nonPeristable, ...storedState };
+		this._state = { ...storedState, ...nonPeristable };
 		this.emit('change', this._state, prevState);
 	}
 }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -33,7 +33,7 @@ export default class Store extends EventEmitter {
 			}
 
 			const storedState = JSON.parse(e.newValue);
-			this.setStoredState(storedState, false);
+			this.setStoredState(storedState);
 		});
 	}
 

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -29,7 +29,7 @@ export default class Store extends EventEmitter {
 
 			if (!e.newValue) {
 				// The localStorage has been removed
-				location.reload();
+				return location.reload();
 			}
 
 			const storedState = JSON.parse(e.newValue);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -37,7 +37,8 @@ const initialState = {
 	unread: null,
 };
 
-export const store = new Store(initialState, { dontPersist: ['messages', 'typing'] });
+const dontPersist = ['messages', 'typing', 'loading', 'alerts', 'unread', 'noMoreMessages'];
+export const store = new Store(initialState, { dontPersist });
 
 if (process.env.NODE_ENV === 'development') {
 	store.on('change', (state, prevState, partialState) => {

--- a/widget-demo.html
+++ b/widget-demo.html
@@ -48,12 +48,12 @@
 			var h = d.getElementsByTagName(s)[0],
 				j = d.createElement(s);
 			j.async = true;
-			j.src = 'build/rocketchat-livechat.min.js?_=' + Math.random();
+			j.src = '/livechat/1.0.0/rocketchat-livechat.min.js?_=' + Math.random();
 			h.parentNode.insertBefore(j, h);
-		})(window, document, 'script', 'http://localhost:8080');
+		})(window, document, 'script', '/livechat?version=1.0.0');
 
 		RocketChat(function() {
-			this.setCustomField('protocol', 'bla bla bla');
+			this.setCustomField('key-test', 'value test');
 		});
 	</script>
 </body>

--- a/widget-demo.html
+++ b/widget-demo.html
@@ -48,12 +48,12 @@
 			var h = d.getElementsByTagName(s)[0],
 				j = d.createElement(s);
 			j.async = true;
-			j.src = '/livechat/1.0.0/rocketchat-livechat.min.js?_=' + Math.random();
+			j.src = 'build/rocketchat-livechat.min.js?_=' + Math.random();
 			h.parentNode.insertBefore(j, h);
-		})(window, document, 'script', '/livechat?version=1.0.0');
+		})(window, document, 'script', 'http://localhost:8080');
 
 		RocketChat(function() {
-			this.setCustomField('key-test', 'value test');
+			this.setCustomField('protocol', 'bla bla bla');
 		});
 	</script>
 </body>


### PR DESCRIPTION
When the Widget is running in multiples tabs(same origin) and the user interaction with it, even though we store the data(and the state) of the widget in the `localStorage`, the changes don't reflect on other tabs than the one on which the user is chatting.
Another example: In case the livechat fired trigger messages, the agent fetched from the server may not be the same since the state of each widget has not been synchronized between all open tabs, which provides a very bad user experience.

To fix this wrong behavior, this implementation relies on the `onStorage` event handler for processing storage events and keep the state of each open widget synchronized.
