### PR TITLE
[NEW] Add new API method the set the default Agent before chatting

### DIFF
--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -74,7 +74,7 @@ const api = {
 
 	setAgent({ _id, username, ...props } = {}) {
 		if (!_id || !username) {
-			return console.log('The fields _id and username are mandatory.');
+			return console.warn('The fields _id and username are mandatory.');
 		}
 
 		store.setState({

--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -70,7 +70,7 @@ const api = {
 		updateIframeGuestData({ department: '' });
 	},
 
-	setAgent({ _id, username, status, ...props } = {}) {
+	setAgent({ _id, username, ...props } = {}) {
 		if (!_id || !username) {
 			return console.log('The fields _id and username are mandatory.');
 		}

--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -70,6 +70,21 @@ const api = {
 		updateIframeGuestData({ department: '' });
 	},
 
+	setAgent({ _id, username, status, ...props } = {}) {
+		if (!_id || !username) {
+			return console.log('The fields _id and username are mandatory.');
+		}
+
+		store.setState({
+			defaultAgent: {
+				_id,
+				username,
+				ts: Date.now(),
+				...props,
+			},
+		});
+	},
+
 	setExpanded(expanded) {
 		store.setState({ expanded });
 	},

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -192,7 +192,7 @@ export const loadMoreMessages = async () => {
 export const defaultRoomParams = () => {
 	const params = {};
 
-	const { triggerAgent: { agent } = {} } = store.state;
+	const { defaultAgent: agent = {} } = store.state;
 	if (agent && agent._id) {
 		Object.assign(params, { agentId: agent._id });
 	}

--- a/src/lib/triggers.js
+++ b/src/lib/triggers.js
@@ -19,14 +19,9 @@ const getAgent = (triggerAction) => {
 
 		if (params.sender === 'queue') {
 			const { state } = store;
-			const { triggerAgent, iframe: { guest: { department } } } = state;
-
-			if (triggerAgent) {
-				const cacheAgent = triggerAgent;
-				// cache valid for 1h
-				if (cacheAgent.ts && Date.now() - cacheAgent.ts < agentCacheExpiry) {
-					return resolve(cacheAgent.agent);
-				}
+			const { defaultAgent, iframe: { guest: { department } } } = state;
+			if (defaultAgent && defaultAgent.ts && Date.now() - defaultAgent.ts < agentCacheExpiry) {
+				return resolve(defaultAgent); // cache valid for 1
 			}
 
 			let agent;
@@ -36,7 +31,7 @@ const getAgent = (triggerAction) => {
 				return reject(error);
 			}
 
-			store.setState({ triggerAgent: { agent, ts: Date.now() } });
+			store.setState({ defaultAgent: { ...agent, ts: Date.now() } });
 			resolve(agent);
 		} else if (params.sender === 'custom') {
 			resolve({

--- a/src/widget.js
+++ b/src/widget.js
@@ -269,7 +269,10 @@ function initialize(params) {
 			case 'language':
 				setLanguage(params[method]);
 				continue;
-			default:
+				case 'agent':
+					setAgent(params[method]);
+					continue;
+				default:
 				continue;
 		}
 	}

--- a/src/widget.js
+++ b/src/widget.js
@@ -269,10 +269,10 @@ function initialize(params) {
 			case 'language':
 				setLanguage(params[method]);
 				continue;
-				case 'agent':
-					setAgent(params[method]);
-					continue;
-				default:
+			case 'agent':
+				setAgent(params[method]);
+				continue;
+			default:
 				continue;
 		}
 	}

--- a/src/widget.js
+++ b/src/widget.js
@@ -266,6 +266,10 @@ function clearDepartment() {
 	callHook('clearDepartment');
 }
 
+function setAgent(agent) {
+	callHook('setAgent', agent);
+}
+
 function setLanguage(language) {
 	callHook('setLanguage', language);
 }
@@ -356,6 +360,7 @@ window.RocketChat.livechat = {
 	setGuestToken,
 	setGuestName,
 	setGuestEmail,
+	setAgent,
 	registerGuest,
 	setLanguage,
 	showWidget,


### PR DESCRIPTION
Adds the `setAgent` method which allows setting the default agent before the visitor starts chatting.
Also, since the agent who sends trigger messages is the same who will serve the conversation, the store prop `triggerAgent` has been renamed/unified to `defaultAgent` prop.