### PR TITLE
[IMPROVE] Keep trigger messages after the conversation starts

### DIFF
--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -10,8 +10,8 @@ import { parentCall } from './parentCall';
 const createOrUpdateGuest = async (guest) => {
 	const { token } = guest;
 	token && await store.setState({ token });
-	await Livechat.grantVisitor({ visitor: { ...guest } });
-	await loadConfig();
+	const user = await Livechat.grantVisitor({ visitor: { ...guest } });
+	store.setState({ user });
 };
 
 const updateIframeGuestData = (data) => {

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -149,20 +149,19 @@ Livechat.onMessage(async (message) => {
 });
 
 export const loadMessages = async () => {
-	const { room: { _id: rid } = {} } = store.state;
+	const { messages: storedMessages, room: { _id: rid } = {} } = store.state;
+	const previousMessages = getGreetingMessages(storedMessages);
 
 	if (!rid) {
 		return;
 	}
 
 	await store.setState({ loading: true });
-
-	const rawMessages = await Livechat.loadMessages(rid);
+	const rawMessages = (await Livechat.loadMessages(rid)).concat(previousMessages);
 	const messages = (await normalizeMessages(rawMessages)).map(transformAgentInformationOnMessage);
 
 	await initRoom();
-	await store.setState({ messages: (messages || []).reverse(), noMoreMessages: false });
-	await store.setState({ loading: false });
+	await store.setState({ messages: (messages || []).reverse(), noMoreMessages: false, loading: false });
 
 	if (messages && messages.length) {
 		const lastMessage = messages[messages.length - 1];
@@ -185,8 +184,8 @@ export const loadMoreMessages = async () => {
 	await store.setState({
 		messages: (moreMessages || []).reverse(),
 		noMoreMessages: messages.length + 10 > moreMessages.length,
+		loading: false,
 	});
-	await store.setState({ loading: false });
 };
 
 export const defaultRoomParams = () => {
@@ -199,6 +198,10 @@ export const defaultRoomParams = () => {
 
 	return params;
 };
+
+export const getGreetingMessages = (messages) => {
+	return messages && messages.filter((msg) => msg.trigger);
+}
 
 store.on('change', (state, prevState) => {
 	// Cross-tab communication

--- a/src/lib/triggers.js
+++ b/src/lib/triggers.js
@@ -114,6 +114,7 @@ class Triggers {
 						u: agent,
 						ts: ts.toISOString(),
 						_id: createToken(),
+						trigger: true,
 					};
 
 					await store.setState({

--- a/src/routes/Register/container.js
+++ b/src/routes/Register/container.js
@@ -29,9 +29,9 @@ export class RegisterContainer extends Component {
 
 		await dispatch({ loading: true, department });
 		try {
-			await Livechat.grantVisitor({ visitor: { ...fields, token } });
+			const user = await Livechat.grantVisitor({ visitor: { ...fields, token } });
+			await dispatch({ user });
 			parentCall('callback', ['pre-chat-form-submit', fields]);
-			await loadConfig();
 		} finally {
 			await dispatch({ loading: false });
 		}

--- a/src/routes/SwitchDepartment/container.js
+++ b/src/routes/SwitchDepartment/container.js
@@ -27,9 +27,8 @@ export class SwitchDepartmentContainer extends Component {
 		}
 
 		if (!room) {
-			await Livechat.grantVisitor({ visitor: { department, token } });
-			await loadConfig();
-			await dispatch({ alerts: (alerts.push({ id: createToken(), children: I18n.t('Department switched'), success: true }), alerts) });
+			const user = await Livechat.grantVisitor({ visitor: { department, token } });
+			await dispatch({ user, alerts: (alerts.push({ id: createToken(), children: I18n.t('Department switched'), success: true }), alerts) });
 			return history.go(-1);
 		}
 


### PR DESCRIPTION
The trigger messages are not persistent messages, so they're displayed on the client-side only.
They were being removed from the `localStorage` after a new conversation started, but now they'll continue to be displayed after a visitor starts chatting, maintaining the expected behaviour of this feature.

Also, other improvements are part of this PR, such as reducing the number of unnecessary calls to the `loadConfig` method, which was being called just to reload the `state` of the local configuration.

![Screen Shot 2020-03-17 at 13 47 53](https://user-images.githubusercontent.com/59577424/76881764-6474ac00-6858-11ea-96d9-31054c5f58f0.png)
