### PR TITLE
Improvements on sending offline messages

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -126,7 +126,7 @@ export const sortArrayByColumn = (array, column, inverted) => array.sort((a, b) 
 });
 
 export const parseOfflineMessage = (fields = {}) => {
-	const host = location.protocol.concat('//').concat(window.location.hostname);
+	const host = window.location.origin;
 	return Object.assign(fields, { host });
 };
 export const normalizeDOMRect = ({ left, top, right, bottom }) => ({ left, top, right, bottom });

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -125,6 +125,10 @@ export const sortArrayByColumn = (array, column, inverted) => array.sort((a, b) 
 	return 1;
 });
 
+export const parseOfflineMessage = (fields = {}) => {
+	const host = location.protocol.concat('//').concat(window.location.hostname);
+	return Object.assign(fields, { host });
+};
 export const normalizeDOMRect = ({ left, top, right, bottom }) => ({ left, top, right, bottom });
 
 

--- a/src/routes/LeaveMessage/component.js
+++ b/src/routes/LeaveMessage/component.js
@@ -13,19 +13,28 @@ const defaultMessage = I18n.t('We are not online right now. Please, leave a mess
 const defaultUnavailableMessage = ''; // TODO
 
 export default class LeaveMessage extends Component {
-	state = {
-		name: { value: '' },
-		email: { value: '' },
-		department: null,
-		message: { value: '' },
-	}
-
 	validations = {
 		name: [Validations.nonEmpty],
 		email: [Validations.nonEmpty, Validations.email],
 		department: [],
 		message: [Validations.nonEmpty],
 	}
+
+	getDefaultState = () => {
+		const { hasDepartmentField, departments } = this.props;
+
+		let department = null;
+		if (hasDepartmentField && departments && departments.length > 0) {
+			department = { value: '' };
+		}
+
+		return {
+			name: { value: '' },
+			email: { value: '' },
+			department,
+			message: { value: '' },
+		};
+	};
 
 	getValidableFields = () => Object.keys(this.validations)
 		.map((fieldName) => (this.state[fieldName] ? { fieldName, ...this.state[fieldName] } : null))
@@ -39,6 +48,8 @@ export default class LeaveMessage extends Component {
 			this.setState({ [fieldName]: { ...this.state[fieldName], value, error, showError: false } });
 		}
 	}
+
+	reset = () => this.setState(this.getDefaultState());
 
 	isValid = () => this.getValidableFields().every(({ error } = {}) => !error)
 
@@ -55,7 +66,7 @@ export default class LeaveMessage extends Component {
 
 	handleMessageChange = this.handleFieldChange('message')
 
-	handleSubmit = (event) => {
+	handleSubmit = async (event) => {
 		event.preventDefault();
 
 		if (this.props.onSubmit) {
@@ -63,23 +74,16 @@ export default class LeaveMessage extends Component {
 				.filter(([, state]) => state !== null)
 				.map(([name, { value }]) => ({ [name]: value }))
 				.reduce((values, entry) => ({ ...values, ...entry }), {});
-			this.props.onSubmit(values);
+
+			if (await this.props.onSubmit(values)) {
+				this.reset();
+			}
 		}
 	}
 
 	constructor(props) {
 		super(props);
-
-		const { hasDepartmentField, departments } = props;
-
-		if (hasDepartmentField && departments) {
-			if (departments.length > 0) {
-				this.state.department = { value: '' };
-			} else {
-				this.state.department = null;
-			}
-		}
-
+		this.setState(this.getDefaultState());
 		this.validateAll();
 	}
 

--- a/src/routes/LeaveMessage/container.js
+++ b/src/routes/LeaveMessage/container.js
@@ -4,24 +4,29 @@ import { Livechat } from '../../api';
 import { parentCall } from '../../lib/parentCall';
 import { Consumer } from '../../store';
 import LeaveMessage from './component';
-import { createToken } from '../../components/helpers';
+import { ModalManager } from '../../components/Modal';
+import { createToken, parseOfflineMessage } from '../../components/helpers';
 
 
 export class LeaveMessageContainer extends Component {
 	handleSubmit = async (fields) => {
-		const { alerts, dispatch, successMessage } = this.props;
+		const { alerts, dispatch } = this.props;
 
 		await dispatch({ loading: true });
 		try {
-			const message = await Livechat.sendOfflineMessage(fields);
-			const success = { id: createToken(), children: successMessage || message, success: true, timeout: 5000 };
-			await dispatch({ alerts: (alerts.push(success), alerts) });
+			const payload = parseOfflineMessage(fields);
+			const text = await Livechat.sendOfflineMessage(payload);
+			await ModalManager.alert({
+				text,
+			});
 			parentCall('callback', ['offline-form-submit', fields]);
+			return true;
 		} catch (error) {
 			const { data: { message } } = error;
 			console.error(message);
-			const alert = { id: createToken(), children: message, error: true, timeout: 0 };
+			const alert = { id: createToken(), children: message, error: true, timeout: 5000 };
 			await dispatch({ alerts: (alerts.push(alert), alerts) });
+			return false;
 		} finally {
 			await dispatch({ loading: false });
 		}


### PR DESCRIPTION
CLOSES #396 

Improvements on the Offline Message Form:
- Show a modal message after the message is sent successfully instead of an alert on the top of the form. The previous alert was not clear enough and users where clicking on the submit button several times. Now the users will get a modal alert like shown below:

<img width="494" alt="Screen Shot 2020-04-24 at 17 48 42" src="https://user-images.githubusercontent.com/59577424/80256477-26d42180-8655-11ea-9619-cbfa302aaf40.png">

- We're now resetting the form after the message is sent;
- We're now sharing the `hostname` from where the message has been sent;
