### PR TITLE
[FIX] UIKit ActionsBlock layout for smaller screen devices

### DIFF
--- a/src/components/uiKit/message/ActionsBlock/styles.scss
+++ b/src/components/uiKit/message/ActionsBlock/styles.scss
@@ -2,7 +2,7 @@
 	display: flex;
 
 	margin: 0 8px 8px;
-	flex-flow: row nowrap;
+	flex-flow: row wrap;
 
 	&__item {
 		margin: 0 4px 4px;


### PR DESCRIPTION
### Before:
![before](https://user-images.githubusercontent.com/34130764/91257558-dea24880-e787-11ea-9043-ca673de4585b.gif)


### After:
![image](https://user-images.githubusercontent.com/34130764/91257381-5459e480-e787-11ea-8561-8fcb797bf48f.png)
