### PR TITLE
[FIX] UiKit interaction call

### DIFF
--- a/src/lib/uiKit.js
+++ b/src/lib/uiKit.js
@@ -124,7 +124,11 @@ export const triggerAction = async ({
 		};
 
 		const result = await Promise.race([
-			Livechat.post(`apps/ui.interaction/${ appId }`, params),
+			fetch(`${ Livechat.client.host }/api/${ encodeURI(`apps/ui.interaction/${ appId }`) }`, {
+				method: 'POST',
+				body: Livechat.client.getBody(Object.assign(params, Livechat.credentials)),
+				headers: Livechat.client.getHeaders(),
+			}).then(Livechat.client.handle),
 			new Promise((_, reject) => {
 				setTimeout(() => {
 					reject(new Error(triggerId));


### PR DESCRIPTION
Interaction with UIKit blocks were sending POST requests to `[HOST]/api/v1/apps/ui.interaction/[APP_ID]`, when the correct route is `[HOST]/api/apps/ui.interaction/[APP_ID]`