### PR TITLE
[FIX] Transpile widget.js with Babel

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: ['@babel/preset-env'],
+					},
+				},
+			},
+		],
+	},
+};


### PR DESCRIPTION
It transpiles `widget.js` to ES5 to be parseable by IE11.