### PR TITLE
[NEW] Show agent nickname

### DIFF
--- a/src/components/Screen/index.js
+++ b/src/components/Screen/index.js
@@ -29,7 +29,7 @@ class ScreenHeader extends Component {
 	headerTitle = () => {
 		const { agent, queueInfo, title } = this.props;
 		if (agent && agent.name) {
-			return agent.name;
+			return agent.nickname ? agent.nickname : agent.name;
 		}
 
 		if (queueInfo && queueInfo.spot && queueInfo.spot > 0) {

--- a/src/routes/Chat/container.js
+++ b/src/routes/Chat/container.js
@@ -390,6 +390,7 @@ export const ChatConnector = ({ ref, ...props }) => (
 				agent={agent ? {
 					_id: agent._id,
 					name: agent.name,
+					nickname: agent.nickname,
 					status: agent.status,
 					email: agent.emails && agent.emails[0] && agent.emails[0].address,
 					username: agent.username,


### PR DESCRIPTION
Proposed changes:
==========
This feature displays agent nickname if available

Currently, the admins are just able to define if the Agent's information will be displayed or not.

A new setting that will allow admins to select one of the following options:

Name
Nickname(Name as fallback)
None
