### PR TITLE
[FIX] Emoji picker not rendering

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,10 @@ module.exports = (env, argv) => [
 				'.js',
 				'.jsx',
 			],
+			alias: {
+				'react': 'preact/compat',
+				'react-dom': 'preact/compat',
+			}
 		},
 		node: {
 			console: false,
@@ -215,6 +219,10 @@ module.exports = (env, argv) => [
 				'.js',
 				'.jsx',
 			],
+			alias: {
+				'react': 'preact/compat',
+				'react-dom': 'preact/compat',
+			}
 		},
 		node: {
 			console: false,


### PR DESCRIPTION
It was a problem between emoji-mart and webpack, just some configurations in webpack file was necessary.