### PR TITLE
[FIX] Support Webpack relative output path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = (env, argv) => [
 		},
 		output: {
 			path: path.resolve(__dirname, './build'),
-			publicPath: argv.mode === 'production' ? '/livechat/' : '/',
+			publicPath: argv.mode === 'production' ? 'livechat/' : '/',
 			filename: argv.mode === 'production' ? '[name].[chunkhash:5].js' : '[name].js',
 			chunkFilename: '[name].chunk.[chunkhash:5].js',
 		},
@@ -189,7 +189,7 @@ module.exports = (env, argv) => [
 			inline: true,
 			hot: true,
 			compress: true,
-			publicPath: argv.mode === 'production' ? '/livechat/' : '/',
+			publicPath: argv.mode === 'production' ? 'livechat/' : '/',
 			contentBase: path.resolve(__dirname, './src'),
 			port: 8080,
 			host: '0.0.0.0',
@@ -229,7 +229,7 @@ module.exports = (env, argv) => [
 		},
 		output: {
 			path: path.resolve(__dirname, './build'),
-			publicPath: argv.mode === 'production' ? '/livechat/' : '/',
+			publicPath: argv.mode === 'production' ? 'livechat/' : '/',
 			filename: 'rocketchat-livechat.min.js',
 		},
 		module: {


### PR DESCRIPTION
Just a little change that makes able you use like: 
http://youdomain.com**/anything/**livechat, not only http://youdomain.com/livechat

It's the same like this: https://github.com/RocketChat/Rocket.Chat.Livechat/pull/292
CLOSES https://github.com/RocketChat/Rocket.Chat.Livechat/issues/504