### PR TITLE
[FIX] Rendering emojis before transform markdown into HTML.

### DIFF
--- a/src/components/Emoji/shortnameToUnicode.js
+++ b/src/components/Emoji/shortnameToUnicode.js
@@ -27,14 +27,8 @@ const unescapeHTML = (string) => {
 	return string.replace(/&(?:amp|#38|#x26|lt|#60|#x3C|gt|#62|#x3E|apos|#39|#x27|quot|#34|#x22);/ig, (match) => unescaped[match]);
 };
 
-const addSpaceBetweenHTMLTags = (stringWithHTML) => {
-	const regexTags = new RegExp('<\/?.[^>]*>', 'ig');
-	return stringWithHTML.replace(regexTags, (entire) => ` ${ entire } `);
-}
-
 const shortnameToUnicode = (stringMessage) => {
 	stringMessage = stringMessage.replace(shortnamePattern, replaceShortNameWithUnicode);
-	stringMessage = addSpaceBetweenHTMLTags(stringMessage);
 	stringMessage = stringMessage.replace(regAscii, (entire, m1, m2, m3) => {
 		if (!m3 || !(unescapeHTML(m3) in ascii)) {
 			return entire;

--- a/src/components/Emoji/shortnameToUnicode.js
+++ b/src/components/Emoji/shortnameToUnicode.js
@@ -29,9 +29,7 @@ const unescapeHTML = (string) => {
 
 const addSpaceBetweenHTMLTags = (stringWithHTML) => {
 	const regexTags = new RegExp('<\/?.[^>]*>', 'ig');
-	return stringWithHTML.replace(regexTags, (entire) => {
-		return ` ${ entire } `;
-	})
+	return stringWithHTML.replace(regexTags, (entire) => ` ${ entire } `);
 }
 
 const shortnameToUnicode = (stringMessage) => {

--- a/src/components/Emoji/shortnameToUnicode.js
+++ b/src/components/Emoji/shortnameToUnicode.js
@@ -30,7 +30,7 @@ const unescapeHTML = (string) => {
 const addSpaceBetweenHTMLTags = (stringWithHTML) => {
 	const regexTags = new RegExp('<\/?.[^>]*>', 'ig');
 	return stringWithHTML.replace(regexTags, (entire) => {
-		return ` ${entire} `;
+		return ` ${ entire } `;
 	})
 }
 

--- a/src/components/Emoji/shortnameToUnicode.js
+++ b/src/components/Emoji/shortnameToUnicode.js
@@ -27,10 +27,17 @@ const unescapeHTML = (string) => {
 	return string.replace(/&(?:amp|#38|#x26|lt|#60|#x3C|gt|#62|#x3E|apos|#39|#x27|quot|#34|#x22);/ig, (match) => unescaped[match]);
 };
 
-const shortnameToUnicode = (str) => {
-	str = str.replace(shortnamePattern, replaceShortNameWithUnicode);
+const addSpaceBetweenHTMLTags = (stringWithHTML) => {
+	const regexTags = new RegExp('<\/?.[^>]*>', 'ig');
+	return stringWithHTML.replace(regexTags, (entire) => {
+		return ` ${entire} `;
+	})
+}
 
-	str = str.replace(regAscii, (entire, m1, m2, m3) => {
+const shortnameToUnicode = (stringMessage) => {
+	stringMessage = stringMessage.replace(shortnamePattern, replaceShortNameWithUnicode);
+	stringMessage = addSpaceBetweenHTMLTags(stringMessage);
+	stringMessage = stringMessage.replace(regAscii, (entire, m1, m2, m3) => {
 		if (!m3 || !(unescapeHTML(m3) in ascii)) {
 			return entire;
 		}
@@ -39,7 +46,7 @@ const shortnameToUnicode = (str) => {
 		return ascii[m3];
 	});
 
-	return str;
+	return stringMessage;
 };
 
 export default shortnameToUnicode;

--- a/src/components/Messages/MessageText/emoji.js
+++ b/src/components/Messages/MessageText/emoji.js
@@ -9,9 +9,9 @@ const emojiRanges = [
 ].join('|');
 
 // this func is called for each emoji, input-> emoji shortname, o/p-> emoji icon in html format
-const transformEmojisToNormalSize = (emoji) => `<span>${ emoji }<span>`;
+const transformEmojisToNormalSize = (emoji) => `<span>${ emoji }</span>`;
 
-const transformEmojisToLargeSize = (emoji) => `<span style="font-size:2rem">${ emoji }<span>`;
+const transformEmojisToLargeSize = (emoji) => `<span style="font-size:2rem">${ emoji }</span>`;
 
 const removeSpaces = (str) => str && str.replace(/\s/g, '');
 
@@ -22,15 +22,14 @@ const isOnlyEmoji = (str) => {
 	return !removeAllEmoji(str).length;
 };
 
-const renderEmojis = (textWithHtml, origPlainText) => {
+const renderEmojis = (origPlainText) => {
 	const textWithOnlyUnicode = shortnameToUnicode(origPlainText);
-	textWithHtml = shortnameToUnicode(textWithHtml);
 
 	if (isOnlyEmoji(textWithOnlyUnicode)) {
-		return textWithHtml.replace(new RegExp(emojiUnicode, 'g'), transformEmojisToLargeSize);
+		return textWithOnlyUnicode.replace(new RegExp(emojiUnicode, 'g'), transformEmojisToLargeSize);
 	}
 
-	return textWithHtml.replace(new RegExp(emojiUnicode, 'g'), transformEmojisToNormalSize);
+	return textWithOnlyUnicode.replace(new RegExp(emojiUnicode, 'g'), transformEmojisToNormalSize);
 };
 
 export default renderEmojis;

--- a/src/components/Messages/MessageText/index.js
+++ b/src/components/Messages/MessageText/index.js
@@ -13,7 +13,7 @@ export const MessageText = memo(({
 }) => (
 	<div
 		// eslint-disable-next-line react/no-danger
-		dangerouslySetInnerHTML={{ __html: renderEmojis(renderMarkdown(text), text) }}
+		dangerouslySetInnerHTML={{ __html: renderMarkdown(renderEmojis(text)) }}
 		className={createClassName(styles, 'message-text', { system }, [className])}
 		style={style}
 	/>

--- a/src/components/Messages/MessageText/markdown.js
+++ b/src/components/Messages/MessageText/markdown.js
@@ -2,6 +2,7 @@ import MarkdownIt from 'markdown-it';
 
 
 const md = new MarkdownIt({
+	html: true,
 	breaks: true,
 	linkify: true,
 	typographer: true,


### PR DESCRIPTION
Rendering the emojis before HTML (transformed by markdown-it plugin)

![image](https://user-images.githubusercontent.com/2493803/97048973-4b03b300-1551-11eb-8e04-0bfc9d0a2d9b.png)

