### PR TITLE
[FIX] Livechat window cannot be restored in popout mode

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -109,7 +109,7 @@ export class App extends Component {
 		const dispatchEvent = () => {
 			dispatchRestore();
 			store.off('storageSynced', dispatchEvent);
-		};
+		}
 		if (undocked) {
 			store.on('storageSynced', dispatchEvent);
 		} else {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -30,6 +30,7 @@ function isRTL(s) {
 export class App extends Component {
 	state = {
 		initialized: false,
+		poppedOut: false,
 	}
 
 	handleRoute = async () => {
@@ -154,6 +155,16 @@ export class App extends Component {
 		I18n.on('change', this.handleLanguageChange);
 	}
 
+	checkPoppedOutWindow() {
+		// Checking if the window is poppedOut and setting parent minimized if yes for the restore purpose
+		const { dispatch } = this.props;
+		const poppedOut = queryString.parse(window.location.search).mode === 'popout';
+		this.setState({ poppedOut });
+		if (poppedOut) {
+			dispatch({ minimized: false });
+		}
+	}
+
 	async initialize() {
 		// TODO: split these behaviors into composable components
 		await Connection.init();
@@ -162,6 +173,7 @@ export class App extends Component {
 		Hooks.init();
 		userPresence.init();
 		this.initWidget();
+		this.checkPoppedOutWindow();
 
 		this.setState({ initialized: true });
 		parentCall('ready');
@@ -193,13 +205,10 @@ export class App extends Component {
 		expanded,
 		alerts,
 		modal,
-	}, { initialized }) => {
+	}, { initialized, poppedOut }) => {
 		if (!initialized) {
 			return null;
 		}
-
-		const poppedOut = queryString.parse(window.location.search).mode === 'popout';
-
 		const screenProps = {
 			notificationsEnabled: sound && sound.enabled,
 			minimized: !poppedOut && (minimized || undocked),

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -103,13 +103,12 @@ export class App extends Component {
 
 	handleRestore = () => {
 		parentCall('restoreWindow');
-		const { dispatch } = this.props;
-		const { undocked } = this.props;
+		const { dispatch, undocked } = this.props;
 		const dispatchRestore = () => dispatch({ minimized: false, undocked: false });
 		const dispatchEvent = () => {
 			dispatchRestore();
 			store.off('storageSynced', dispatchEvent);
-		}
+		};
 		if (undocked) {
 			store.on('storageSynced', dispatchEvent);
 		} else {
@@ -120,7 +119,7 @@ export class App extends Component {
 	handleOpenWindow = () => {
 		parentCall('openPopout');
 		const { dispatch } = this.props;
-		dispatch({ undocked: true });
+		dispatch({ undocked: true, minimized: false });
 	}
 
 	handleDismissAlert = (id) => {
@@ -141,7 +140,7 @@ export class App extends Component {
 
 	initWidget() {
 		setWidgetLanguage();
-		const { minimized, iframe: { visible } } = this.props;
+		const { minimized, iframe: { visible }, dispatch } = this.props;
 		parentCall(minimized ? 'minimizeWindow' : 'restoreWindow');
 		parentCall(visible ? 'showWidget' : 'hideWidget');
 
@@ -149,6 +148,7 @@ export class App extends Component {
 		this.handleVisibilityChange();
 		window.addEventListener('beforeunload', () => {
 			visibility.removeListener(this.handleVisibilityChange);
+			dispatch({ minimized: true, undocked: false });
 		});
 
 		I18n.on('change', this.handleLanguageChange);


### PR DESCRIPTION
After maximizing the window of the livechat widget (pop-out) and closing it again, the livechat cannot be restored.
Also, a page refresh does not help.