### PR TITLE
[FIX] Visitor's messages are not aligned properly on Mozilla Firefox

### DIFF
--- a/src/components/Messages/MessageContainer/styles.scss
+++ b/src/components/Messages/MessageContainer/styles.scss
@@ -7,7 +7,7 @@ $message-container-compact-margin: 0 0 ($default-padding / 4) 0;
 	display: flex;
 
 	margin: $message-container-margin;
-	justify-content: start;
+	justify-content: flex-start;
 
 	&--compact {
 		margin: $message-container-compact-margin;


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/2493803/98391400-5e287f80-2035-11eb-89c7-001821a6f1d2.png)

Console
![image](https://user-images.githubusercontent.com/2493803/98391527-887a3d00-2035-11eb-99c5-89f3699ce15e.png)

**After**
![image](https://user-images.githubusercontent.com/2493803/98391720-c5deca80-2035-11eb-8388-92cbf3f720bd.png)



