### PR TITLE
[FIX] Rocket.Chat 3.0.12 Livechat issue about Korean IME #403

### DIFF
--- a/src/components/Composer/index.js
+++ b/src/components/Composer/index.js
@@ -56,13 +56,17 @@ const replaceCaret = (el) => {
 	}
 };
 
+let inputLock = false;
+
 export class Composer extends Component {
 	handleRef = (el) => {
 		this.el = el;
 	}
 
 	handleInput = (onChange) => () => {
-		onChange && onChange(this.el.innerText);
+		if (!inputLock) {
+			onChange && onChange(this.el.innerText);
+		}
 	}
 
 	handleKeypress = (onSubmit) => (event) => {
@@ -246,6 +250,16 @@ export class Composer extends Component {
 						onClick: this.handleClick,
 					}
 				)}
+
+				oncompositionstart={(e)=>{
+					inputLock = true;
+				}}
+
+				oncompositionend={(e)=>{
+					inputLock = false;
+					onChange && onChange(this.el.innerText);
+				}}
+
 				className={createClassName(styles, 'composer__input')}
 			/>
 			{post}


### PR DESCRIPTION
This way can fix IME input method problem(Such as, Korean、Japanese、Chinese).
Because preact.js has SyntheticEvent issue.
Therefore, oncompositionstart & oncompositionend are all lowercase.
[Reference](https://github.com/preactjs/preact/issues/1978)