### PR TITLE
[FIX] Add sanitizer to prevent XSS attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"css-vars-ponyfill": "^2.3.2",
 		"date-fns": "^2.15.0",
 		"desvg": "^1.0.2",
+		"dompurify": "^2.2.6",
 		"emoji-mart": "^3.0.0",
 		"history": "^5.0.0",
 		"i18nline": "^2.0.1",

--- a/src/components/Composer/index.js
+++ b/src/components/Composer/index.js
@@ -1,3 +1,4 @@
+import { sanitize } from 'dompurify';
 import mem from 'mem';
 import { h, Component } from 'preact';
 
@@ -62,7 +63,7 @@ export class Composer extends Component {
 	}
 
 	handleInput = (onChange) => () => {
-		onChange && onChange(this.el.innerText);
+		onChange && onChange(sanitize(this.el.innerText));
 	}
 
 	handleKeypress = (onSubmit) => (event) => {

--- a/src/components/Messages/MessageText/markdown.js
+++ b/src/components/Messages/MessageText/markdown.js
@@ -1,3 +1,4 @@
+import { sanitize } from 'dompurify';
 import MarkdownIt from 'markdown-it';
 
 
@@ -80,4 +81,4 @@ md.use((md) => {
 	});
 });
 
-export const renderMarkdown = (...args) => md.render(...args);
+export const renderMarkdown = (...args) => sanitize(md.render(...args));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5684,6 +5684,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.2.6.tgz#54945dc5c0b45ce5ae228705777e8e59d7b2edc4"
+  integrity sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ==
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
This PR solve a Cross Site Scripting (XSS) vulnerability.

Messages and composer are reading HTML code, so it's necessary a `sanitizer` to strip out everything that contains dangerous HTML.

Package: [DOMPurify](https://github.com/cure53/DOMPurify) (same of RC)

### Before
![image](https://user-images.githubusercontent.com/2493803/109338337-e3ce7600-7844-11eb-93be-ddf3a93561ac.png)

### After
![image](https://user-images.githubusercontent.com/2493803/109339130-f09f9980-7845-11eb-969b-166b4e24d0be.png)

https://user-images.githubusercontent.com/2493803/109339791-e7fb9300-7846-11eb-9777-d4bdfca6f4ac.mp4



