### PR TITLE
email-validation

### DIFF
--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -25,7 +25,7 @@ export class Form extends MemoizedComponent {
 export const Validations = {
 	nonEmpty: ({ value }) => (!value ? I18n.t('Field required') : undefined),
 
-	email: ({ value }) => (!/^\S+@\S+\.\S+/.test(String(value).toLowerCase()) ? I18n.t('Invalid email') : null),
+	email: ({ value }) => (!/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(String(value).toLowerCase()) ? I18n.t('Invalid email') : null),
 
 	custom: ({ value, pattern }) => (new RegExp(pattern, 'i').test(String(value)) ? null : I18n.t('Invalid value')),
 };


### PR DESCRIPTION
#561 [FIX] Email-validation 
Done email validation in offline registration form .
<img width="1277" alt="Screenshot 2021-03-16 at 2 19 41 PM" src="https://user-images.githubusercontent.com/56799414/111312935-ce02e280-8685-11eb-9c0e-65c238f6cd83.png">
'send' button is activated for correct email address . 