### PR TITLE
[NEW] WebRTC-call in new tab for mobile devices

### DIFF
--- a/src/components/Calls/CallIFrame.js
+++ b/src/components/Calls/CallIFrame.js
@@ -6,12 +6,19 @@ import { createClassName } from '../helpers';
 import styles from './styles.scss';
 
 
-export const CallIframe = () => {
+export const CallIframe = (props) => {
 	const { token, room } = store.state;
 	const url = `${ Livechat.client.host }/meet/${ room._id }?token=${ token }`;
+	const callInNewTab = async () => {
+		window.open(url);
+		await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: props.time } });
+		await store.setState({ incomingCallAlert: { show: false, callProvider: props.callProvider } });
+	};
 	return (
-		<div className={createClassName(styles, 'call-iframe')}>
-			<iframe className={createClassName(styles, 'call-iframe__content')} allow='camera;microphone' src={url} />
+		<div>
+			{(window.innerWidth <= 800) && (window.innerHeight <= 630)
+				? <div className={createClassName(styles, 'call-iframe')}> <iframe className={createClassName(styles, 'call-iframe__content')} allow='camera;microphone' src={url} />
+				</div> : callInNewTab() }
 		</div>
 	);
 };

--- a/src/components/Calls/CallIFrame.js
+++ b/src/components/Calls/CallIFrame.js
@@ -6,19 +6,13 @@ import { createClassName } from '../helpers';
 import styles from './styles.scss';
 
 
-export const CallIframe = (props) => {
+export const CallIframe = () => {
 	const { token, room } = store.state;
 	const url = `${ Livechat.client.host }/meet/${ room._id }?token=${ token }`;
-	const callInNewTab = async () => {
-		window.open(url);
-		await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: props.time } });
-		await store.setState({ incomingCallAlert: { show: false, callProvider: props.callProvider } });
-	};
+
 	return (
-		<div>
-			{(window.innerWidth <= 800) && (window.innerHeight <= 630)
-				? <div className={createClassName(styles, 'call-iframe')}> <iframe className={createClassName(styles, 'call-iframe__content')} allow='camera;microphone' src={url} />
-				</div> : callInNewTab() }
+		<div className={createClassName(styles, 'call-iframe')}>
+			<iframe className={createClassName(styles, 'call-iframe__content')} allow='camera;microphone' src={url} />
 		</div>
 	);
 };

--- a/src/components/Calls/CallNotification.js
+++ b/src/components/Calls/CallNotification.js
@@ -9,7 +9,7 @@ import constants from '../../lib/constants';
 import store from '../../store';
 import { Avatar } from '../Avatar';
 import { Button } from '../Button';
-import { createClassName, getAvatarUrl } from '../helpers';
+import { createClassName, getAvatarUrl, isMobileDevice } from '../helpers';
 import styles from './styles.scss';
 
 
@@ -33,7 +33,7 @@ export const CallNotification = ({ callProvider, callerUsername, url, dispatch, 
 				break;
 			}
 			case constants.webrtcCallStartedMessageType: {
-				if (window.innerWidth <= 800 && window.innerHeight >= 630) {
+				if (isMobileDevice()) {
 					callInNewTab();
 					break;
 				}

--- a/src/components/Calls/CallNotification.js
+++ b/src/components/Calls/CallNotification.js
@@ -20,7 +20,7 @@ export const CallNotification = ({ callProvider, callerUsername, url, dispatch, 
 		const { token, room } = store.state;
 		const url = `${ Livechat.client.host }/meet/${ room._id }?token=${ token }`;
 		await dispatch({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: { time } }, incomingCallAlert: { show: false, callProvider } });
-		window.open(url);
+		window.open(url, room._id);
 	};
 
 	const acceptClick = async () => {

--- a/src/components/Calls/CallNotification.js
+++ b/src/components/Calls/CallNotification.js
@@ -6,6 +6,7 @@ import I18n from '../../i18n';
 import PhoneAccept from '../../icons/phone.svg';
 import PhoneDecline from '../../icons/phoneOff.svg';
 import constants from '../../lib/constants';
+import store from '../../store';
 import { Avatar } from '../Avatar';
 import { Button } from '../Button';
 import { createClassName, getAvatarUrl } from '../helpers';
@@ -15,15 +16,27 @@ import styles from './styles.scss';
 export const CallNotification = ({ callProvider, callerUsername, url, dispatch, time, rid } = { callProvider: undefined, callerUsername: undefined, dispatch: undefined, time: undefined }) => {
 	const [show, setShow] = useState(true);
 
+	const callInNewTab = async () => {
+		const { token, room } = store.state;
+		const url = `${ Livechat.client.host }/meet/${ room._id }?token=${ token }`;
+		await dispatch({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: { time } }, incomingCallAlert: { show: false, callProvider } });
+		window.open(url);
+	};
+
 	const acceptClick = async () => {
 		setShow(!{ show });
 		await Livechat.updateCallStatus('inProgress', rid);
+
 		switch (callProvider) {
 			case constants.jitsiCallStartedMessageType: {
 				window.open(url);
 				break;
 			}
 			case constants.webrtcCallStartedMessageType: {
+				if (window.innerWidth <= 800 && window.innerHeight >= 630) {
+					callInNewTab();
+					break;
+				}
 				await dispatch({ ongoingCall: { callStatus: 'accept', time: { time } } });
 				break;
 			}

--- a/src/components/Calls/JoinCallButton.js
+++ b/src/components/Calls/JoinCallButton.js
@@ -6,14 +6,14 @@ import VideoIcon from '../../icons/video.svg';
 import constants from '../../lib/constants';
 import store from '../../store';
 import { Button } from '../Button';
-import { createClassName, createToken } from '../helpers';
+import { createClassName } from '../helpers';
 import styles from './styles.scss';
 
 
 export const JoinCallButton = (props) => {
 	const { token, room } = store.state;
-	const clickJoinCall = async () => {
-		const { alerts } = store.state;
+
+	const clickJoinCall = () => {
 		switch (props.callProvider) {
 			case constants.jitsiCallStartedMessageType: {
 				window.open(props.url);
@@ -22,10 +22,6 @@ export const JoinCallButton = (props) => {
 			case constants.webrtcCallStartedMessageType: {
 				window.open(`${ Livechat.client.host }/meet/${ room._id }?token=${ token }`);
 				break;
-			}
-			default: {
-				const alert = { id: createToken(), children: I18n.t('Call already ended'), timeout: 5000 };
-				await store.setState({ alerts: (alerts.push(alert), alerts) });
 			}
 		}
 	};

--- a/src/components/Calls/JoinCallButton.js
+++ b/src/components/Calls/JoinCallButton.js
@@ -20,7 +20,7 @@ export const JoinCallButton = (props) => {
 				break;
 			}
 			case constants.webrtcCallStartedMessageType: {
-				window.open(`${ Livechat.client.host }/meet/${ room._id }?token=${ token }`);
+				window.open(`${ Livechat.client.host }/meet/${ room._id }?token=${ token }`, room._id);
 				break;
 			}
 		}

--- a/src/components/Calls/JoinCallButton.js
+++ b/src/components/Calls/JoinCallButton.js
@@ -30,7 +30,7 @@ export const JoinCallButton = (props) => {
 		}
 	};
 	return (<div>
-		{ props.callStatus === 'accept'
+		{ props.callStatus === 'accept' || props.callStatus === 'ongoingCallInNewTab'
 			? <div className={createClassName(styles, 'joinCall')}>
 				<div className={createClassName(styles, 'joinCall__content')} >
 					<div className={createClassName(styles, 'joinCall__content-videoIcon')} >

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -157,6 +157,14 @@ export const parseOfflineMessage = (fields = {}) => {
 export const normalizeDOMRect = ({ left, top, right, bottom }) => ({ left, top, right, bottom });
 
 
+export const isMobileDevice = () => {
+	if (window.innerWidth <= 800 && window.innerHeight >= 630) {
+		return true;
+	}
+	return false;
+};
+
+
 export const visibility = (() => {
 	if (typeof document.hidden !== 'undefined') {
 		return {

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -210,7 +210,7 @@ export const loadMessages = async () => {
 				return;
 			}
 			if (window.innerWidth <= 800 && window.innerHeight >= 630) {
-				await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: lastMessage.ts }, incomingCallAlert: null });
+				await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: lastMessage.ts }, incomingCallAlert: { show: false, callProvider: lastMessage.t } });
 				return;
 			}
 			await processCallMessage(lastMessage);

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -1,7 +1,7 @@
 import { route } from 'preact-router';
 
 import { Livechat } from '../api';
-import { setCookies, upsert, canRenderMessage, createToken } from '../components/helpers';
+import { setCookies, upsert, canRenderMessage, createToken, isMobileDevice } from '../components/helpers';
 import I18n from '../i18n';
 import { store } from '../store';
 import { normalizeAgent } from './api';
@@ -209,7 +209,7 @@ export const loadMessages = async () => {
 				await store.setState({ ongoingCall: { callStatus: 'ended', time: lastMessage.ts }, incomingCallAlert: null });
 				return;
 			}
-			if (window.innerWidth <= 800 && window.innerHeight >= 630) {
+			if (isMobileDevice()) {
 				await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: lastMessage.ts }, incomingCallAlert: { show: false, callProvider: lastMessage.t } });
 				return;
 			}

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -1,7 +1,7 @@
 import { route } from 'preact-router';
 
 import { Livechat } from '../api';
-import { setCookies, upsert, canRenderMessage, createToken, isMobileDevice } from '../components/helpers';
+import { setCookies, upsert, canRenderMessage, createToken } from '../components/helpers';
 import I18n from '../i18n';
 import { store } from '../store';
 import { normalizeAgent } from './api';

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -185,7 +185,7 @@ Livechat.onMessage(async (message) => {
 });
 
 export const getGreetingMessages = (messages) => messages && messages.filter((msg) => msg.trigger);
-export const getLatestCallMessage = (messages) => messages && messages.filter((msg) => msg.actionLinks && msg.actionLinks.length === 2);
+export const getLatestCallMessage = (messages) => messages && messages.filter((msg) => msg.t === 'livechat_webrtc_video_call' || msg.t === 'livechat_video_call').pop();
 
 export const loadMessages = async () => {
 	const { ongoingCall } = store.state;
@@ -217,9 +217,9 @@ export const loadMessages = async () => {
 		if (!latestCallMessage) {
 			return;
 		}
-		store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: latestCallMessage[0].ts }, incomingCallAlert: { show: false, callProvider: latestCallMessage[0].t } });
+		store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: latestCallMessage.ts }, incomingCallAlert: { show: false, callProvider: latestCallMessage.t } });
 	} else if (callStatus === 'ringing') {
-		processCallMessage(latestCallMessage[0]);
+		processCallMessage(latestCallMessage);
 	}
 };
 

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -50,13 +50,13 @@ export const processCallMessage = async (message) => {
 };
 
 const processMessage = async (message) => {
-	const { incomingCallAlert, ongoingCall } = store.state;
+	const { incomingCallAlert } = store.state;
 
 	if (message.t === 'livechat-close') {
 		closeChat(message);
 	} else if (message.t === 'command') {
 		commands[message.msg] && commands[message.msg]();
-	} else if (message.endTs || (ongoingCall && ongoingCall.callStatus === 'declined')) {
+	} else if (message.endTs) {
 		await store.setState({ ongoingCall: { callStatus: 'ended', time: message.ts }, incomingCallAlert: null });
 	} else if (!incomingCallAlert && (message.t === constants.webrtcCallStartedMessageType || message.t === constants.jitsiCallStartedMessageType)) {
 		await processCallMessage(message);
@@ -217,9 +217,9 @@ export const loadMessages = async () => {
 		if (!latestCallMessage) {
 			return;
 		}
-		store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: latestCallMessage.ts }, incomingCallAlert: { show: false, callProvider: latestCallMessage[0].t } });
+		store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: latestCallMessage[0].ts }, incomingCallAlert: { show: false, callProvider: latestCallMessage[0].t } });
 	} else if (callStatus === 'ringing') {
-		processCallMessage(latestCallMessage);
+		processCallMessage(latestCallMessage[0]);
 	}
 };
 

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -55,7 +55,7 @@ const processMessage = async (message) => {
 		closeChat(message);
 	} else if (message.t === 'command') {
 		commands[message.msg] && commands[message.msg]();
-	} else if (message.endTs && ((ongoingCall && ongoingCall.callStatus === 'declined') || incomingCallAlert)) {
+	} else if (message.endTs && ((ongoingCall && (ongoingCall.callStatus === 'declined' || ongoingCall.callStatus === 'ongoingCallInNewTab')) || incomingCallAlert)) {
 		await store.setState({ ongoingCall: { callStatus: 'ended', time: message.ts }, incomingCallAlert: null });
 	} else if (!incomingCallAlert && (message.t === constants.webrtcCallStartedMessageType || message.t === constants.jitsiCallStartedMessageType)) {
 		await processCallMessage(message);
@@ -207,6 +207,10 @@ export const loadMessages = async () => {
 		if (lastMessage.t === constants.webrtcCallStartedMessageType || lastMessage.t === constants.jitsiCallStartedMessageType) {
 			if (lastMessage.endTs) {
 				await store.setState({ ongoingCall: { callStatus: 'ended', time: lastMessage.ts }, incomingCallAlert: null });
+				return;
+			}
+			if (window.innerWidth <= 800 && window.innerHeight >= 630) {
+				await store.setState({ ongoingCall: { callStatus: 'ongoingCallInNewTab', time: lastMessage.ts }, incomingCallAlert: null });
 				return;
 			}
 			await processCallMessage(lastMessage);


### PR DESCRIPTION
If an agent calls the visitor and the visitor is accessing the live chat widget from mobile, then after accepting the call, webrtc-call will start in a new tab instead of starting the call in iframe. And also add join call button will be there in  livechat widget, which can be used to join the call, if visitor by mistake close the webrtc-call tab.
