### PR TITLE
[NEW] Notify agent on call decline

### DIFF
--- a/src/components/Calls/CallNotification.js
+++ b/src/components/Calls/CallNotification.js
@@ -12,12 +12,12 @@ import { createClassName, getAvatarUrl } from '../helpers';
 import styles from './styles.scss';
 
 
-export const CallNotification = ({ callProvider, callerUsername, url, dispatch, time, rid } = { callProvider: undefined, callerUsername: undefined, dispatch: undefined, time: undefined }) => {
+export const CallNotification = ({ callProvider, callerUsername, url, dispatch, time, rid, callId } = { callProvider: undefined, callerUsername: undefined, dispatch: undefined, time: undefined }) => {
 	const [show, setShow] = useState(true);
 
 	const acceptClick = async () => {
 		setShow(!{ show });
-		await Livechat.updateCallStatus('inProgress', rid);
+		await Livechat.updateCallStatus('inProgress', rid, callId);
 		switch (callProvider) {
 			case constants.jitsiCallStartedMessageType: {
 				window.open(url);
@@ -31,7 +31,8 @@ export const CallNotification = ({ callProvider, callerUsername, url, dispatch, 
 	};
 
 	const declineClick = async () => {
-		await Livechat.updateCallStatus('declined', rid);
+		await Livechat.updateCallStatus('declined', rid, callId);
+		await Livechat.notifyCallDeclined(rid);
 		await dispatch({ incomingCallAlert: null, ongoingCall: { callStatus: 'declined', time: { time } } });
 	};
 

--- a/src/lib/room.js
+++ b/src/lib/room.js
@@ -35,6 +35,7 @@ export const processCallMessage = async (message) => {
 			callerUsername: message.u.username,
 			rid: message.rid,
 			time: message.ts,
+			callId: message._id,
 		},
 		ongoingCall: {
 			callStatus: 'ring',


### PR DESCRIPTION
Earlier on declining the call, the visitor was only updating the status in the database and not notifying the agent due to which the agent on the meet page still waited for the visitor to join after the decline event.

https://user-images.githubusercontent.com/51796498/129457306-f37e7bef-e24b-47dc-afc6-71f6354c0e39.mp4

## Proposed change

https://user-images.githubusercontent.com/51796498/129470189-1a27ff1e-d9ac-4360-92a6-ef5db1fc32eb.mp4

Uses [#144](https://github.com/RocketChat/Rocket.Chat.js.SDK/pull/144)
