### PR TITLE
[FIX] Issues on Custom Livechat messages

### DIFF
--- a/src/routes/LeaveMessage/component.js
+++ b/src/routes/LeaveMessage/component.js
@@ -183,10 +183,10 @@ export default class LeaveMessage extends Component {
 			{...props}
 		>
 			<Screen.Content>
-				<p className={createClassName(styles, 'leave-message__main-message')}>
-					{hasForm ? message || defaultMessage : unavailableMessage || defaultUnavailableMessage}
-				</p>
-
+				<p className={createClassName(styles, 'leave-message__main-message')}
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={{ __html: hasForm ? message || defaultMessage : unavailableMessage || defaultUnavailableMessage }}
+				/>
 				{hasForm && this.renderForm(this.props, this.state)}
 			</Screen.Content>
 			<Screen.Footer />

--- a/src/routes/LeaveMessage/container.js
+++ b/src/routes/LeaveMessage/container.js
@@ -10,14 +10,14 @@ import LeaveMessage from './component';
 
 export class LeaveMessageContainer extends Component {
 	handleSubmit = async (fields) => {
-		const { alerts, dispatch } = this.props;
+		const { alerts, dispatch, successMessage } = this.props;
 
 		await dispatch({ loading: true });
 		try {
 			const payload = parseOfflineMessage(fields);
 			const text = await Livechat.sendOfflineMessage(payload);
 			await ModalManager.alert({
-				text,
+				text: successMessage || text,
 			});
 			parentCall('callback', ['offline-form-submit', fields]);
 			return true;


### PR DESCRIPTION
1. Fix **Offline Success Message** not working

- Setting
![image](https://user-images.githubusercontent.com/34130764/134337822-88184290-5ecf-4d83-8158-73ead386d88c.png)

- The above message should appear here on Livechat when the visitor submits the offline form
![image](https://user-images.githubusercontent.com/34130764/134338175-859e354b-c42a-49c8-926e-90f000a70d14.png)


2. Support HTML content on the **Instructions** message setting

- Setting
![image](https://user-images.githubusercontent.com/34130764/134338421-5c69b64e-860e-40e8-8f9a-dd1a3c98f578.png)

- The above setting would now support rich contents like hyperlinks, new lines, bold, italic, etc using HTML tags. and this content would be visible over here on the offline form
![image](https://user-images.githubusercontent.com/34130764/134338769-753771fb-d4e1-4650-bee0-c035896d3b42.png)
