### PR TITLE
Chore: Add PR title check

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,10 @@
+{
+	"LABEL": {
+	  "name": "Invalid PR Title",
+	  "color": "B60205"
+	},
+	"CHECKS": {
+	  "regexp": "^(?:(?:\\[(NEW|BREAK|IMPROVE|FIX)\\](\\[(ENTERPRISE|APPS)\\])?|(?:Regression|Chore|Bump):) .+|Release [0-9]+\\.[0-9]+\\.[0-9]+)",
+	  "ignoreLabels" : ["[ignore-title]"]
+	}
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,12 @@
+name: "PR Title Checker"
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every PR should follow the same naming convention we have on Rocket.Chat's main repo.