### PR TITLE
[FIX] Hide Livechat if Omnichannel is disabled

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -208,8 +208,12 @@ export class App extends Component {
 		expanded,
 		alerts,
 		modal,
+		config,
 	}, { initialized, poppedOut }) => {
 		if (!initialized) {
+			return null;
+		}
+		if (!config.enabled) {
 			return null;
 		}
 		const screenProps = {


### PR DESCRIPTION
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Turn off Omnichannel from Admin -> Omnichannel
![image](https://user-images.githubusercontent.com/34130764/147763943-5e9886d8-081f-4252-9d30-8a76c7733a78.png)

The start an omnichannel conversation from anywhere like LiveChat, API, app, etc. The simplest way would be to go to `{serverUrl}/livechat` and send a message.

**Before:** The conversation will be started

**Expected Behaviour:** An error should be thrown stating that omnichannel is disabled